### PR TITLE
Added the npm recipe for actions/cache GH actions to speed up builds

### DIFF
--- a/.github/workflows/functions-test.yml
+++ b/.github/workflows/functions-test.yml
@@ -17,6 +17,12 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
+    - uses: actions/cache@v1
+      with:
+        path: ~/.npm
+        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node-
     - name: npm install, build, and test
       run: |
         cd functions/

--- a/.github/workflows/functions-test.yml
+++ b/.github/workflows/functions-test.yml
@@ -17,12 +17,20 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - uses: actions/cache@v1
+    - name: actions/cache (.npm)
+      uses: actions/cache@v1
       with:
         path: ~/.npm
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-node-
+    - name: actions/cache (firebase emulators)
+      uses: actions/cache@v1
+      with:
+        path: ~/.cache/firebase/emulators
+        key: ${{ runner.os }}-emulators-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-emulators-
     - name: npm install, build, and test
       run: |
         cd functions/

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Serverless Backend is implemented by a series of Cloud Function, located in the 
 
 React App for viewing and interacting with the voting record is hosted on [Github Pages](http://brisberg.github.io/friday-fellows-gcf), located in the `app` directory.
 
+Deploy a new version to gh-pages with: `npm run deploy`
+
 
 ## Testing during Development
 

--- a/README.md
+++ b/README.md
@@ -32,4 +32,10 @@ Then start the emulator and access its emulated function URLs.
 
 Cloud function unit tests use the firebase emulator (above) to mock interacts with Firestore. Follow the instructions above to launch the emulator, then from the `functions` directory run the tests with:
 
+`npm run test:jest`
+
+or
+
+To run the emulator and tests in a single step use just:
+
 `npm test`


### PR DESCRIPTION
Following suggestions in:
https://github.com/marketplace/actions/cache
https://help.github.com/en/actions/automating-your-workflow-with-github-actions/caching-dependencies-to-speed-up-workflows

We can add a actions/cache step the testing rules which will cache files installed by NPM in github. This will speed up future builds if the package-lock.json file hasn't changed.