### PR TITLE
Added @firebase/testing to project

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -217,10 +217,57 @@
         }
       }
     },
+    "@firebase/analytics": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.2.7.tgz",
+      "integrity": "sha512-ZpGvppEOk4qID5PZiPyGi5v+LFnXkbknMBm2ARisph1iesmxwgSHhn3QlqghjdVbdxONV2y4YSVUkJNCxCtX9A==",
+      "dev": true,
+      "requires": {
+        "@firebase/analytics-types": "0.2.3",
+        "@firebase/installations": "0.3.6",
+        "@firebase/util": "0.2.34",
+        "tslib": "1.10.0"
+      }
+    },
+    "@firebase/analytics-types": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.2.3.tgz",
+      "integrity": "sha512-8R8V5ZZsg6lDe2EiqgNq3XMQpAHbfStoXqRjdxu7FVCNLb/yxBThANdFXHbh4XxDc7vJEZr90PAjRB+bfGkSyw==",
+      "dev": true
+    },
+    "@firebase/app": {
+      "version": "0.4.25",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.4.25.tgz",
+      "integrity": "sha512-Zf7RsWJhJXqWJ8tp1NQXFTYoEeURVkA+yI6On0SmPAxUo2CG1sXGhUt0TJBnYpKQLeDbhxVx552U85iMaVkvkw==",
+      "dev": true,
+      "requires": {
+        "@firebase/app-types": "0.4.8",
+        "@firebase/logger": "0.1.31",
+        "@firebase/util": "0.2.34",
+        "dom-storage": "2.1.0",
+        "tslib": "1.10.0",
+        "xmlhttprequest": "1.8.0"
+      }
+    },
     "@firebase/app-types": {
       "version": "0.4.8",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.4.8.tgz",
       "integrity": "sha512-VTjWRooelMExK/rKArp6WqnWJJfi8Vs6VuDYDSeMcQ3NpSux2bW1dfJFuzYmiK1+37hEJP1F43DyUDv2lCJquw=="
+    },
+    "@firebase/auth": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.13.1.tgz",
+      "integrity": "sha512-JN/850MuahGea7NZMVbNTl3ASGFqSt8Hx9DuP4s0XZ1U0FcA439nSKGxjD0phn/HpwzYyU+sMxh1gmffuyWKMw==",
+      "dev": true,
+      "requires": {
+        "@firebase/auth-types": "0.9.1"
+      }
+    },
+    "@firebase/auth-types": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.9.1.tgz",
+      "integrity": "sha512-3P+qkJHkPcbyF9mubHGC4Bz2uZ6ha647rhWi3eMihXdD6E+vTEGpAi/KOp6KYvZJRbGbuCrobP61Djay1PuFlA==",
+      "dev": true
     },
     "@firebase/database": {
       "version": "0.5.13",
@@ -242,10 +289,165 @@
         "@firebase/app-types": "0.4.8"
       }
     },
+    "@firebase/firestore": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-1.8.0.tgz",
+      "integrity": "sha512-MOuM2Bpgq9b+GnMJL9ui8aIwTTCSZ0u+qG2R7O8NoQogvB/XDCDjPER7PJfLLZ03yxiSuWKiJ+pu37AqgDIxhg==",
+      "dev": true,
+      "requires": {
+        "@firebase/firestore-types": "1.8.0",
+        "@firebase/logger": "0.1.31",
+        "@firebase/util": "0.2.34",
+        "@firebase/webchannel-wrapper": "0.2.32",
+        "@grpc/proto-loader": "^0.5.0",
+        "grpc": "1.24.2",
+        "tslib": "1.10.0"
+      }
+    },
+    "@firebase/firestore-types": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-1.8.0.tgz",
+      "integrity": "sha512-Zy7IDqtjZPbKB6tP4dKuNks3tCvWOa3VhqEdl4WLyMKhvqh+/d0lzr+0HEEeEWR4IogsnJmLZUjDx0eqvqfCpg==",
+      "dev": true
+    },
+    "@firebase/functions": {
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.4.26.tgz",
+      "integrity": "sha512-ZY3sWKdi7UuKhZ/P05AtzOwPNZCU4oSkpWc1UR+GcYvGtn54e8PVwFvhYBZpo9DyvEgDx/0uXrtMVRvqdYUmDg==",
+      "dev": true,
+      "requires": {
+        "@firebase/functions-types": "0.3.11",
+        "@firebase/messaging-types": "0.3.5",
+        "isomorphic-fetch": "2.2.1",
+        "tslib": "1.10.0"
+      }
+    },
+    "@firebase/functions-types": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.3.11.tgz",
+      "integrity": "sha512-sNLrBzTm6Rzq/QMbCgenhJW2LU+gQx0IMYZJJjz50dhYzQSfirlEdFEo8xm59aWhqCw87AI4XzNSGgu53C2OVA==",
+      "dev": true
+    },
+    "@firebase/installations": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.3.6.tgz",
+      "integrity": "sha512-30RNzx8wBHm5RIPVVxdpSBGohPeOCl5YQ5qCdmx/gImokP9q4GC1i8BOKh/OldXiRY6nMVU2uzPaCpOSZsPFNw==",
+      "dev": true,
+      "requires": {
+        "@firebase/installations-types": "0.2.2",
+        "@firebase/util": "0.2.34",
+        "idb": "3.0.2",
+        "tslib": "1.10.0"
+      }
+    },
+    "@firebase/installations-types": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.2.2.tgz",
+      "integrity": "sha512-ABe4pJbBPYTyUQZ/BzyMZw9VEO+XYrClsxcVZ3WJTlhiu1OuBOeFfdbbsKPlywqwS5cVSM0xO9bJSgiMWQhUfQ==",
+      "dev": true
+    },
     "@firebase/logger": {
       "version": "0.1.31",
       "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.1.31.tgz",
       "integrity": "sha512-1OEJaCMMaaT0VleNwer3bocbd25beR6KZUaHBweLNHEFxaNvniSv+lm83g08dWLBml3ZVOb945hp6m8REFx6/Q=="
+    },
+    "@firebase/messaging": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.5.7.tgz",
+      "integrity": "sha512-JQLhHCo6THIzj74/iGrAxJY3YI05+q9UlHAykr8HkDtmNjFkiVCGLcuCrYcwayvElziGGQ3EQAD+EGAN1BkjCw==",
+      "dev": true,
+      "requires": {
+        "@firebase/installations": "0.3.6",
+        "@firebase/messaging-types": "0.3.5",
+        "@firebase/util": "0.2.34",
+        "tslib": "1.10.0"
+      }
+    },
+    "@firebase/messaging-types": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-types/-/messaging-types-0.3.5.tgz",
+      "integrity": "sha512-pRhKJlE/eXc6uBGCmi7BjBen427lbIVlxUH9aKpu5Nrd8nUQ507WwVVL098A0oY0Kx2AJxjwjmtDjDYCaFm9Hg==",
+      "dev": true
+    },
+    "@firebase/performance": {
+      "version": "0.2.26",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.2.26.tgz",
+      "integrity": "sha512-xQpdBv3dygt7y/mMkixPL9ty1YzTyGyVvazub1QNBqzEyIVRI7Slg03taFQ6551x+JPWmmyUCqH6+dQ4U2+HHg==",
+      "dev": true,
+      "requires": {
+        "@firebase/installations": "0.3.6",
+        "@firebase/logger": "0.1.31",
+        "@firebase/performance-types": "0.0.6",
+        "@firebase/util": "0.2.34",
+        "tslib": "1.10.0"
+      }
+    },
+    "@firebase/performance-types": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.0.6.tgz",
+      "integrity": "sha512-nfiIWBuMVXj+G+xIQwpwQjFhtY85GnywAL1S/CTEMTe6tgc9nA+x9ycFU2rEIl3XVTeaHqs616pe1gYToGpRJQ==",
+      "dev": true
+    },
+    "@firebase/polyfill": {
+      "version": "0.3.29",
+      "resolved": "https://registry.npmjs.org/@firebase/polyfill/-/polyfill-0.3.29.tgz",
+      "integrity": "sha512-Ogc6BUYoyOb64lFAGBjMydoczSHdazMeINTBjEEfSkaDqOi7l/tgk9X+oWYe5mxfPNrdBLREkfQb6oKqFPqydQ==",
+      "dev": true,
+      "requires": {
+        "core-js": "3.4.1",
+        "promise-polyfill": "8.1.3",
+        "whatwg-fetch": "2.0.4"
+      }
+    },
+    "@firebase/remote-config": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.1.7.tgz",
+      "integrity": "sha512-v//JIZZSMwPPuHDK+SmcBPA02UTYT2NiDa+4U42Di2iFG5Q9nlOkrxHIOx6Qqr1t7gDqgC1qBRYBeorTpxbTeA==",
+      "dev": true,
+      "requires": {
+        "@firebase/installations": "0.3.6",
+        "@firebase/logger": "0.1.31",
+        "@firebase/remote-config-types": "0.1.3",
+        "@firebase/util": "0.2.34",
+        "tslib": "1.10.0"
+      }
+    },
+    "@firebase/remote-config-types": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.1.3.tgz",
+      "integrity": "sha512-5niKHAHDEaTF6Ch7Jc91WNCy3ZdKEjYlq0l6tDTyjN0lHp6qJW1IKdS3ExBBRmpqP8vjQOUxSDiIPbIZV3ncHw==",
+      "dev": true
+    },
+    "@firebase/storage": {
+      "version": "0.3.20",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.3.20.tgz",
+      "integrity": "sha512-aKZHC1M20rDKX8Xxkz5gBQgT1g0whk1rVeZaqCIrYyNsTbAEomzgodstFLtbXwhVsV+DwWzynm4G7WDoFpr4HA==",
+      "dev": true,
+      "requires": {
+        "@firebase/storage-types": "0.3.6",
+        "@firebase/util": "0.2.34",
+        "tslib": "1.10.0"
+      }
+    },
+    "@firebase/storage-types": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.3.6.tgz",
+      "integrity": "sha512-yHsYhaFQMryR/lgXIdm1mMQwmyC76HLpQHtAxB5WF9FzwjXishJTn1Qe0+JuSWmlHmYXI3EyrCr/JUAv2OS1wQ==",
+      "dev": true
+    },
+    "@firebase/testing": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@firebase/testing/-/testing-0.16.0.tgz",
+      "integrity": "sha512-2YDnpBe8UDFets9xt6pBppIjXUy7nfAVkOn944r4PmroMejsuEl99C+yQhCjQnZSpLEHvRVHStm85k8h+N+YRw==",
+      "dev": true,
+      "requires": {
+        "@firebase/logger": "0.1.31",
+        "@firebase/util": "0.2.34",
+        "@types/request": "2.48.3",
+        "firebase": "7.5.0",
+        "grpc": "1.24.2",
+        "request": "2.88.0"
+      }
     },
     "@firebase/util": {
       "version": "0.2.34",
@@ -254,6 +456,12 @@
       "requires": {
         "tslib": "1.10.0"
       }
+    },
+    "@firebase/webchannel-wrapper": {
+      "version": "0.2.32",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.2.32.tgz",
+      "integrity": "sha512-kXnsBuzmtcOntliDgxAGJJ8JHPOmZ6KgS2v0/5Fb5KXpN9UIFyeaE8pfdkBG9tESdPmGdKpJz781fEIMdMtd8A==",
+      "dev": true
     },
     "@google-cloud/common": {
       "version": "2.2.3",
@@ -694,6 +902,22 @@
         "@types/node": "*"
       }
     },
+    "@types/bytebuffer": {
+      "version": "5.0.40",
+      "resolved": "https://registry.npmjs.org/@types/bytebuffer/-/bytebuffer-5.0.40.tgz",
+      "integrity": "sha512-h48dyzZrPMz25K6Q4+NCwWaxwXany2FhQg/ErOcdZS1ZpsaDnDMZg8JYLMTGz7uvXKrcKGJUZJlZObyfgdaN9g==",
+      "dev": true,
+      "requires": {
+        "@types/long": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/caseless": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
+      "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==",
+      "dev": true
+    },
     "@types/connect": {
       "version": "3.4.32",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.32.tgz",
@@ -798,6 +1022,31 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
       "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA=="
     },
+    "@types/request": {
+      "version": "2.48.3",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.3.tgz",
+      "integrity": "sha512-3Wo2jNYwqgXcIz/rrq18AdOZUQB8cQ34CXZo+LUwPJNpvRAL86+Kc2wwI8mqpz9Cr1V+enIox5v+WZhy/p3h8w==",
+      "dev": true,
+      "requires": {
+        "@types/caseless": "*",
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "form-data": "^2.5.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+          "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "@types/serve-static": {
       "version": "1.13.3",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.3.tgz",
@@ -811,6 +1060,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
+      "dev": true
+    },
+    "@types/tough-cookie": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.5.tgz",
+      "integrity": "sha512-SCcK7mvGi3+ZNz833RRjFIxrn4gI1PPR3NtuIS+6vMkvmsGjosqTJwRt5bAEFLRz+wtJMWv8+uOnZf2hi2QXTg==",
       "dev": true
     },
     "@types/yargs": {
@@ -1137,6 +1392,16 @@
       "resolved": "https://registry.npmjs.org/as-array/-/as-array-2.0.0.tgz",
       "integrity": "sha1-TwSAXYf4/OjlEbwhCPjl46KH1Uc=",
       "dev": true
+    },
+    "ascli": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ascli/-/ascli-1.0.1.tgz",
+      "integrity": "sha1-vPpZdKYvGOgcq660lzKrSoj5Brw=",
+      "dev": true,
+      "requires": {
+        "colour": "~0.7.1",
+        "optjs": "~3.2.2"
+      }
     },
     "asn1": {
       "version": "0.2.4",
@@ -1631,6 +1896,23 @@
         "readable-stream": "~1.0.32"
       }
     },
+    "bytebuffer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/bytebuffer/-/bytebuffer-5.0.1.tgz",
+      "integrity": "sha1-WC7qSxqHO20CCkjVjfhfC7ps/d0=",
+      "dev": true,
+      "requires": {
+        "long": "~3"
+      },
+      "dependencies": {
+        "long": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
+          "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s=",
+          "dev": true
+        }
+      }
+    },
     "bytes": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
@@ -1958,6 +2240,12 @@
       "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
       "dev": true
     },
+    "colour": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/colour/-/colour-0.7.1.tgz",
+      "integrity": "sha1-nLFpkX7F0SwHNtPoaFdG3xyt93g=",
+      "dev": true
+    },
     "combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -2255,6 +2543,12 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true
+    },
+    "core-js": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.4.1.tgz",
+      "integrity": "sha512-KX/dnuY/J8FtEwbnrzmAjUYgLqtk+cxM86hfG60LGiW3MmltIc2yAmDgBgEkfm0blZhUrdr1Zd84J2Y14mLxzg==",
       "dev": true
     },
     "core-util-is": {
@@ -2642,6 +2936,12 @@
       "integrity": "sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==",
       "dev": true
     },
+    "dom-storage": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/dom-storage/-/dom-storage-2.1.0.tgz",
+      "integrity": "sha512-g6RpyWXzl0RR6OTElHKBl7nwnK87GUyZMYC7JWsB/IA73vpqK2K6LT39x4VepLxlSsWBFrPVLnsSR5Jyty0+2Q==",
+      "dev": true
+    },
     "domexception": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
@@ -2797,6 +3097,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "~0.4.13"
+      }
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -3401,6 +3710,28 @@
       "dev": true,
       "requires": {
         "locate-path": "^3.0.0"
+      }
+    },
+    "firebase": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-7.5.0.tgz",
+      "integrity": "sha512-1ymVJ9Xq9xE9uoQIwFO7yZY/fzUmjOkhkfsQPiQFaG9Ue0EUjZF7HP0NWFdJuYvgf7bLCI6IHJPA6EHbjQoVGw==",
+      "dev": true,
+      "requires": {
+        "@firebase/analytics": "0.2.7",
+        "@firebase/app": "0.4.25",
+        "@firebase/app-types": "0.4.8",
+        "@firebase/auth": "0.13.1",
+        "@firebase/database": "0.5.13",
+        "@firebase/firestore": "1.8.0",
+        "@firebase/functions": "0.4.26",
+        "@firebase/installations": "0.3.6",
+        "@firebase/messaging": "0.5.7",
+        "@firebase/performance": "0.2.26",
+        "@firebase/polyfill": "0.3.29",
+        "@firebase/remote-config": "0.1.7",
+        "@firebase/storage": "0.3.20",
+        "@firebase/util": "0.2.34"
       }
     },
     "firebase-admin": {
@@ -4748,6 +5079,551 @@
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "dev": true
     },
+    "grpc": {
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.24.2.tgz",
+      "integrity": "sha512-EG3WH6AWMVvAiV15d+lr+K77HJ/KV/3FvMpjKjulXHbTwgDZkhkcWbwhxFAoTdxTkQvy0WFcO3Nog50QBbHZWw==",
+      "dev": true,
+      "requires": {
+        "@types/bytebuffer": "^5.0.40",
+        "lodash.camelcase": "^4.3.0",
+        "lodash.clone": "^4.5.0",
+        "nan": "^2.13.2",
+        "node-pre-gyp": "^0.14.0",
+        "protobufjs": "^5.0.3"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "camelcase": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+          "dev": true
+        },
+        "chownr": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "dev": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
+          }
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "debug": {
+          "version": "3.2.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "deep-extend": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "detect-libc": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "fs-minipass": {
+          "version": "1.2.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minipass": "^2.6.0"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "iconv-lite": {
+          "version": "0.4.24",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "ignore-walk": {
+          "version": "3.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimatch": "^3.0.4"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "bundled": true,
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true,
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "minipass": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "1.3.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minipass": "^2.9.0"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "needle": {
+          "version": "2.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "debug": "^3.2.6",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.14.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.1",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.2.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4.4.2"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "abbrev": "1",
+            "osenv": "^0.1.4"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true
+        },
+        "npm-packlist": {
+          "version": "1.4.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "protobufjs": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-5.0.3.tgz",
+          "integrity": "sha512-55Kcx1MhPZX0zTbVosMQEO5R6/rikNXd9b6RQK4KSPcrSIIwoXTtebIczUrXlwaSrbz4x8XUVThGPob1n8I4QA==",
+          "dev": true,
+          "requires": {
+            "ascli": "~1",
+            "bytebuffer": "~5",
+            "glob": "^7.0.5",
+            "yargs": "^3.10.0"
+          }
+        },
+        "rc": {
+          "version": "1.2.8",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "deep-extend": "^0.6.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true,
+          "dev": true
+        },
+        "semver": {
+          "version": "5.7.1",
+          "bundled": true,
+          "dev": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "tar": {
+          "version": "4.4.13",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.8.6",
+            "minizlib": "^1.2.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.3"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "wide-align": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "string-width": "^1.0.2 || 2"
+          }
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+          "dev": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+          "dev": true
+        },
+        "yallist": {
+          "version": "3.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "yargs": {
+          "version": "3.32.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+          "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^2.0.1",
+            "cliui": "^3.0.3",
+            "decamelize": "^1.1.1",
+            "os-locale": "^1.4.0",
+            "string-width": "^1.0.1",
+            "window-size": "^0.1.4",
+            "y18n": "^3.2.0"
+          }
+        }
+      }
+    },
     "gtoken": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-4.1.0.tgz",
@@ -5013,6 +5889,12 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "idb": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-3.0.2.tgz",
+      "integrity": "sha512-+FLa/0sTXqyux0o6C+i2lOR0VoS60LU/jzUo5xjfY6+7sEEgy4Gz1O7yFBXvjd7N0NyIGWIRg8DcQSLEG+VSPw==",
+      "dev": true
+    },
     "ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
@@ -5119,6 +6001,12 @@
       "requires": {
         "loose-envify": "^1.0.0"
       }
+    },
+    "invert-kv": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+      "dev": true
     },
     "ip-regex": {
       "version": "2.1.0",
@@ -5425,6 +6313,34 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
+    },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "dev": true,
+      "requires": {
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
+      },
+      "dependencies": {
+        "is-stream": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+          "dev": true
+        },
+        "node-fetch": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+          "dev": true,
+          "requires": {
+            "encoding": "^0.1.11",
+            "is-stream": "^1.0.1"
+          }
+        }
+      }
     },
     "isstream": {
       "version": "0.1.2",
@@ -6253,6 +7169,15 @@
         }
       }
     },
+    "lcid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "dev": true,
+      "requires": {
+        "invert-kv": "^1.0.0"
+      }
+    },
     "left-pad": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
@@ -6338,6 +7263,12 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+    },
+    "lodash.clone": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
+      "integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y=",
+      "dev": true
     },
     "lodash.defaults": {
       "version": "4.2.0",
@@ -6771,8 +7702,7 @@
       "version": "2.14.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
       "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -7115,6 +8045,12 @@
         "word-wrap": "~1.2.3"
       }
     },
+    "optjs": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/optjs/-/optjs-3.2.2.tgz",
+      "integrity": "sha1-aabOicRCpEQDFBrS+bNwvVu29O4=",
+      "dev": true
+    },
     "ora": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/ora/-/ora-3.4.0.tgz",
@@ -7134,6 +8070,15 @@
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
+    },
+    "os-locale": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "dev": true,
+      "requires": {
+        "lcid": "^1.0.0"
+      }
     },
     "os-tmpdir": {
       "version": "1.0.2",
@@ -7400,6 +8345,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
+    "promise-polyfill": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.3.tgz",
+      "integrity": "sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g==",
       "dev": true
     },
     "prompts": {
@@ -9651,6 +10602,12 @@
         }
       }
     },
+    "window-size": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+      "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
+      "dev": true
+    },
     "winston": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/winston/-/winston-1.1.2.tgz",
@@ -9745,6 +10702,12 @@
       "version": "0.1.27",
       "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
       "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk=",
+      "dev": true
+    },
+    "xmlhttprequest": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
+      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=",
       "dev": true
     },
     "xtend": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -29,6 +29,7 @@
     "node": "^8.13.0"
   },
   "devDependencies": {
+    "@firebase/testing": "^0.16.0",
     "@types/jest": "^24.0.23",
     "firebase-functions-test": "^0.1.7",
     "firebase-tools": "^7.8.1",

--- a/functions/src/getAllSeasons.test.ts
+++ b/functions/src/getAllSeasons.test.ts
@@ -1,19 +1,22 @@
 // tslint:disable-next-line: no-import-side-effect
 import 'jest';
 
+import * as firebase from '@firebase/testing';
 import admin from 'firebase-admin';
 import * as functions from 'firebase-functions';
 
+import {PROJECT_ID} from './config';
 import {CONFIG_COLLECTION, SYNC_STATE_KEY} from './model/firestore';
 import {GetAllSeasonsRequest, GetAllSeasonsResponse} from './model/service';
 import {MockRequest, MockResponse} from './testing/express-helpers';
 import {loadTestDataToFirestore} from './testing/loadTestData';
 
-const testEnv = require('firebase-functions-test')();
+const testEnv = require('firebase-functions-test')({projectId: PROJECT_ID});
 import {getAllSeasons} from './getAllSeasons.f';
 
 describe('getAllSeasons', () => {
   beforeEach(async () => {
+    await firebase.clearFirestoreData({projectId: PROJECT_ID});
     await loadTestDataToFirestore();
   });
   afterEach(() => {

--- a/functions/src/getSeries.test.ts
+++ b/functions/src/getSeries.test.ts
@@ -1,18 +1,22 @@
 // tslint:disable-next-line: no-import-side-effect
 import 'jest';
+
+import * as firebase from '@firebase/testing';
 import admin from 'firebase-admin';
 import * as functions from 'firebase-functions';
 import functionsTest from 'firebase-functions-test';
 
+import {PROJECT_ID} from './config';
 import {GetAllSeriesRequest, GetAllSeriesResponse} from './model/service';
 import {MockRequest, MockResponse} from './testing/express-helpers';
 import {loadTestDataToFirestore} from './testing/loadTestData';
 
-const testEnv = functionsTest();
+const testEnv = functionsTest({projectId: PROJECT_ID});
 import {getSeries} from './getSeries.f';
 
 describe('getSeries', () => {
   beforeEach(async () => {
+    await firebase.clearFirestoreData({projectId: PROJECT_ID});
     await loadTestDataToFirestore();
   });
   afterEach(() => {

--- a/functions/src/syncFromVotingSheet.test.ts
+++ b/functions/src/syncFromVotingSheet.test.ts
@@ -1,22 +1,27 @@
 // tslint:disable-next-line: no-import-side-effect
 import 'jest';
 
+import * as firebase from '@firebase/testing';
 import admin from 'firebase-admin';
 import * as functions from 'firebase-functions';
 import functionsTest from 'firebase-functions-test';
 
+import {PROJECT_ID} from './config';
 import {mockResponse} from './helpers/testing/mockSpreadsheetResponse';
 import {CONFIG_COLLECTION, SeasonModel, SEASONS_COLLECTION, SYNC_STATE_KEY} from './model/firestore';
 import {SyncFromVotingSheetRequest, SyncFromVotingSheetResponse} from './model/service';
 import {MockRequest, MockResponse} from './testing/express-helpers';
 
-const testEnv = functionsTest();
+const testEnv = functionsTest({projectId: PROJECT_ID});
 admin.initializeApp({
   credential: admin.credential.applicationDefault(),
 });
 import {syncFromVotingSheet} from './syncFromVotingSheet.f';
 
 describe('syncFromVotingSheet', () => {
+  beforeEach(async () => {
+    await firebase.clearFirestoreData({projectId: PROJECT_ID});
+  });
   afterEach(() => {
     testEnv.cleanup();
   });

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -16,5 +16,8 @@
   ],
   "include": [
     "src",
+  ],
+  "exclude": [
+    "src/__mocks__",
   ]
 }


### PR DESCRIPTION
They fixed @firebase/testing so it requires the same gRPC binary as the rest of the toolkit so I can now use it.

Using this in tests allows us to clear the firestore data between tests.