### PR TITLE
Adding a 'setSeriesId' cloud function

### DIFF
--- a/app/src/app/App.tsx
+++ b/app/src/app/App.tsx
@@ -3,7 +3,7 @@ import './App.css';
 import { reducer, initialState } from '../state/reducer';
 import { AppActions } from '../state/actions';
 import axios from 'axios';
-import { Route, Switch, Redirect, useParams } from 'react-router-dom';
+import { Route, Switch, Redirect } from 'react-router-dom';
 import SeasonList from './SeasonList';
 import SeasonDetail from './SeasonDetail';
 import AppHeader from './AppHeader';

--- a/app/src/app/App.tsx
+++ b/app/src/app/App.tsx
@@ -43,6 +43,26 @@ const App: React.FC<AppProps> = ({ backendURI }) => {
     fetchSeasonData();
   }, [backendURI])
 
+  // Load all season data on start using effect Hook
+  // https://www.robinwieruch.de/react-hooks-fetch-data
+  useEffect(() => {
+    const fetchSeasonData = async () => {
+      try {
+        dispatch(AppActions.fetchSeasonsStart());
+        const resp = await axios.get<GetAllSeasonsResponse>(backendURI + '/getAllSeasons');
+
+        const lastSyncMs = resp.data.lastSyncMs;
+        const lastSync = lastSyncMs ? new Date(lastSyncMs) : undefined
+        dispatch(AppActions.fetchSeasonsSuccess({ json: resp.data.seasons, lastSync }));
+      } catch (e) {
+        console.log(e);
+        // this.setState({...this.state, isFetching: false});
+      }
+    }
+
+    fetchSeasonData();
+  }, [backendURI])
+
   const handleStartDateChanged = async (newDate: Date | null, season: SeasonModel) => {
     const payload: SetSeasonStartDateRequest = {
       sheetId: season.sheetId,
@@ -55,6 +75,10 @@ const App: React.FC<AppProps> = ({ backendURI }) => {
         startDate: newDate,
       }))
     }
+  }
+
+  const handleSeriesIdChanged = () => {
+    console.log("handleSeriesIdChanged unimplemented");
   }
 
   function AppFooter() {
@@ -80,8 +104,11 @@ const App: React.FC<AppProps> = ({ backendURI }) => {
             <SeasonList seasons={state.seasons} lastSyncDate={state.lastSync} loading={state.loadingSeasons} onStartDateChanged={handleStartDateChanged} />
           </Route>
           <Route path='/s/:seasonId' render={({ match }) => (
-            <SeasonDetail season={state.seasons.find((season) => String(season.sheetId) === match.params.seasonId)}
-              onStartDateChanged={handleStartDateChanged} />
+            <SeasonDetail
+              season={state.seasons.find((season) => String(season.sheetId) === match.params.seasonId)}
+              seriesList={state.seriesList}
+              onStartDateChanged={handleStartDateChanged}
+              onSeriesIdChanged={handleSeriesIdChanged} />
           )} />
         </Switch>
       </div>

--- a/app/src/app/App.tsx
+++ b/app/src/app/App.tsx
@@ -106,7 +106,7 @@ const App: React.FC<AppProps> = ({ backendURI }) => {
           <Route path='/s/:seasonId' render={({ match }) => (
             <SeasonDetail
               season={state.seasons.find((season) => String(season.sheetId) === match.params.seasonId)}
-              seriesList={state.seriesList}
+              seriesList={state.seriesForSeason}
               onStartDateChanged={handleStartDateChanged}
               onSeriesIdChanged={handleSeriesIdChanged} />
           )} />

--- a/app/src/app/App.tsx
+++ b/app/src/app/App.tsx
@@ -8,7 +8,7 @@ import SeasonList from './SeasonList';
 import SeasonDetail from './SeasonDetail';
 import AppHeader from './AppHeader';
 import OnDeck from './OnDeck';
-import { SeasonModel } from '../../../model/firestore';
+import { SeasonModel, SeriesModel } from '../../../model/firestore';
 import { SetSeasonStartDateRequest } from '../../../model/service';
 
 interface AppProps {
@@ -57,8 +57,8 @@ const App: React.FC<AppProps> = ({ backendURI }) => {
     }
   }
 
-  const handleSeriesIdChanged = () => {
-    console.log("handleSeriesIdChanged unimplemented");
+  const handleSeriesIdChanged = (series: SeriesModel, seriesId: number) => {
+    console.log("handleSeriesIdChanged unimplemented: new ID: " + seriesId);
   }
 
   function AppFooter() {

--- a/app/src/app/App.tsx
+++ b/app/src/app/App.tsx
@@ -9,7 +9,7 @@ import SeasonDetail from './SeasonDetail';
 import AppHeader from './AppHeader';
 import OnDeck from './OnDeck';
 import { SeasonModel, SeriesModel } from '../../../model/firestore';
-import { SetSeasonStartDateRequest } from '../../../model/service';
+import { SetSeasonStartDateRequest, SetSeriesIdRequest } from '../../../model/service';
 
 interface AppProps {
   backendURI: string;
@@ -57,8 +57,19 @@ const App: React.FC<AppProps> = ({ backendURI }) => {
     }
   }
 
-  const handleSeriesIdChanged = (series: SeriesModel, seriesId: number) => {
-    console.log("handleSeriesIdChanged unimplemented: new ID: " + seriesId);
+  const handleSeriesIdChanged = async (series: SeriesModel, seasonId: number, index: number, seriesId: number) => {
+    const payload: SetSeriesIdRequest = {
+      seasonId: seasonId,
+      row: index,
+      seriesId: seriesId,
+    }
+    const resp = await axios.post(backendURI + '/setSeriesId', payload)
+    if (resp.status === 200) {
+      dispatch(AppActions.setSeriesId({
+        series: series,
+        seriesId: seriesId,
+      }))
+    }
   }
 
   function AppFooter() {

--- a/app/src/app/App.tsx
+++ b/app/src/app/App.tsx
@@ -3,7 +3,7 @@ import './App.css';
 import { reducer, initialState } from '../state/reducer';
 import { AppActions } from '../state/actions';
 import axios from 'axios';
-import { Route, Switch, Redirect } from 'react-router-dom';
+import { Route, Switch, Redirect, useParams } from 'react-router-dom';
 import SeasonList from './SeasonList';
 import SeasonDetail from './SeasonDetail';
 import AppHeader from './AppHeader';
@@ -22,26 +22,6 @@ interface GetAllSeasonsResponse {
 
 const App: React.FC<AppProps> = ({ backendURI }) => {
   const [state, dispatch] = useReducer(reducer, initialState);
-
-  // Load all season data on start using effect Hook
-  // https://www.robinwieruch.de/react-hooks-fetch-data
-  useEffect(() => {
-    const fetchSeasonData = async () => {
-      try {
-        dispatch(AppActions.fetchSeasonsStart());
-        const resp = await axios.get<GetAllSeasonsResponse>(backendURI + '/getAllSeasons');
-
-        const lastSyncMs = resp.data.lastSyncMs;
-        const lastSync = lastSyncMs ? new Date(lastSyncMs) : undefined
-        dispatch(AppActions.fetchSeasonsSuccess({ json: resp.data.seasons, lastSync }));
-      } catch (e) {
-        console.log(e);
-        // this.setState({...this.state, isFetching: false});
-      }
-    }
-
-    fetchSeasonData();
-  }, [backendURI])
 
   // Load all season data on start using effect Hook
   // https://www.robinwieruch.de/react-hooks-fetch-data
@@ -105,6 +85,8 @@ const App: React.FC<AppProps> = ({ backendURI }) => {
           </Route>
           <Route path='/s/:seasonId' render={({ match }) => (
             <SeasonDetail
+              dispatch={dispatch}
+              backendURI={backendURI}
               season={state.seasons.find((season) => String(season.sheetId) === match.params.seasonId)}
               seriesList={state.seriesForSeason}
               onStartDateChanged={handleStartDateChanged}

--- a/app/src/app/SeasonDetail.tsx
+++ b/app/src/app/SeasonDetail.tsx
@@ -101,7 +101,7 @@ interface SeasonDetailProps {
   season: SeasonModel | undefined;
   seriesList: SeriesModel[];
   onStartDateChanged: (newDate: Date | null, season: SeasonModel) => void;
-  onSeriesIdChanged: (series: SeriesModel, seriesId: number) => void;
+  onSeriesIdChanged: (series: SeriesModel, seasonId: number, index: number, seriesId: number) => void;
 }
 
 const SeasonDetail: React.FC<SeasonDetailProps> = ({ dispatch, backendURI, season, seriesList = [], onStartDateChanged, onSeriesIdChanged }) => {
@@ -140,8 +140,7 @@ const SeasonDetail: React.FC<SeasonDetailProps> = ({ dispatch, backendURI, seaso
   const handleSeriesIdDialogConfirm = (seriesId: number) => {
     setDialogOpen(false);
     const series = seriesList[editingIndex];
-    // dispatch(AppActions.setSeriesId({ series, seriesId }));
-    onSeriesIdChanged(series, seriesId);
+    onSeriesIdChanged(series, season.sheetId, editingIndex, seriesId);
     setEditingIndex(-1);
   }
 

--- a/app/src/app/SeasonDetail.tsx
+++ b/app/src/app/SeasonDetail.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import './SeasonDetail.css';
-import { useParams } from 'react-router-dom';
+import { useParams, Link } from 'react-router-dom';
 import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import { MuiPickersUtilsProvider, KeyboardDatePicker } from '@material-ui/pickers';
 import DateFnsUtils from '@date-io/date-fns';
-import { Tooltip, Icon, Paper } from '@material-ui/core';
-import { SeasonModel } from '../../../model/firestore';
+import { Tooltip, Icon, Paper, Table, TableHead, TableRow, TableCell, TableBody } from '@material-ui/core';
+import { SeasonModel, SeriesModel } from '../../../model/firestore';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -31,6 +31,10 @@ const useStyles = makeStyles((theme: Theme) =>
       margin: 'auto',
       maxWidth: '60vw',
     },
+    root: {
+      overflowX: 'auto',
+      margin: '0 10px',
+    },
     table: {
       minWidth: 650,
     },
@@ -39,10 +43,12 @@ const useStyles = makeStyles((theme: Theme) =>
 
 interface SeasonDetailProps {
   season: SeasonModel | undefined;
+  seriesList: SeriesModel[];
   onStartDateChanged: Function;
+  onSeriesIdChanged: Function;
 }
 
-const SeasonDetail: React.FC<SeasonDetailProps> = ({ season, onStartDateChanged }) => {
+const SeasonDetail: React.FC<SeasonDetailProps> = ({ season, seriesList = [], onStartDateChanged, onSeriesIdChanged }) => {
   const { seasonId } = useParams();
   const classes = useStyles();
 
@@ -75,8 +81,32 @@ const SeasonDetail: React.FC<SeasonDetailProps> = ({ season, onStartDateChanged 
           <Icon className="push-left warning-icon text-top">warning</Icon>
         </Tooltip>}
       </Paper>
-      <p>{seasonId}</p>
-      <p>{JSON.stringify(season)}</p>
+      <Paper className={classes.root}>
+        <Table className={classes.table} aria-label="simple table">
+          <TableHead>
+            <TableRow>
+              <TableCell>Series Name</TableCell>
+              <TableCell align="right">AniList&nbsp;ID</TableCell>
+              <TableCell align="right">MAL&nbsp;ID</TableCell>
+              <TableCell align="right">Type</TableCell>
+              <TableCell align="right">Episodes</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {seriesList.map((series) => (
+              <TableRow key={series.titleEn}>
+                <TableCell component="th" scope="row">
+                  {series.titleEn}
+                </TableCell>
+                <TableCell align="right">{series.idAL}</TableCell>
+                <TableCell align="right">{series.idMal}</TableCell>
+                <TableCell align="right">{series.type}</TableCell>
+                <TableCell align="right">{series.episodes}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </Paper>
     </div>
   );
 }

--- a/app/src/state/actions.ts
+++ b/app/src/state/actions.ts
@@ -1,11 +1,14 @@
-import {SeasonModel} from '../../../model/firestore';
+import {SeasonModel, SeriesModel} from '../../../model/firestore';
 
 import {ActionsUnion, createAction, createActionPayload} from './action_utils';
 
 
 export const FETCH_SEASONS_START = 'ACTION_FETCH_SEASONS_START'
 export const FETCH_SEASONS_SUCCESS = 'ACTION_FETCH_SEASONS_SUCCESS';
-export const SET_SEASON_START_DATE = 'SET_SEASON_START_DATE';
+export const FETCH_SERIES_START = 'ACTION_FETCH_SERIES_START'
+export const FETCH_SERIES_SUCCESS = 'ACTION_FETCH_SERIES_SUCCESS';
+export const SET_SEASON_START_DATE = 'ACTION_SET_SEASON_START_DATE';
+export const SET_SERIES_ID = 'SET_SERIES_ID';
 
 export const AppActions = {
   fetchSeasonsStart:
@@ -13,9 +16,16 @@ export const AppActions = {
   fetchSeasonsSuccess: createActionPayload<
       typeof FETCH_SEASONS_SUCCESS,
       {json: SeasonModel[], lastSync: Date | undefined}>(FETCH_SEASONS_SUCCESS),
+  fetchSeriesStart: createAction<typeof FETCH_SERIES_START>(FETCH_SERIES_START),
+  fetchSeriesSuccess:
+      createActionPayload<typeof FETCH_SERIES_SUCCESS, {json: SeriesModel[]}>(
+          FETCH_SERIES_SUCCESS),
   setSeasonStartDate: createActionPayload<
       typeof SET_SEASON_START_DATE,
-      {season: SeasonModel, startDate: Date | null}>(SET_SEASON_START_DATE)
+      {season: SeasonModel, startDate: Date | null}>(SET_SEASON_START_DATE),
+  setSeriesId: createActionPayload<
+      typeof SET_SERIES_ID, {series: SeriesModel, seriesId: number}>(
+      SET_SERIES_ID)
 };
 
 export type AllActions = ActionsUnion<typeof AppActions>;

--- a/app/src/state/reducer.ts
+++ b/app/src/state/reducer.ts
@@ -1,6 +1,6 @@
-import {SeasonModel} from '../../../model/firestore';
+import {SeasonModel, SeriesModel} from '../../../model/firestore';
 
-import {AllActions, FETCH_SEASONS_START, FETCH_SEASONS_SUCCESS, SET_SEASON_START_DATE} from './actions';
+import {AllActions, FETCH_SEASONS_START, FETCH_SEASONS_SUCCESS, FETCH_SERIES_START, FETCH_SERIES_SUCCESS, SET_SEASON_START_DATE, SET_SERIES_ID} from './actions';
 
 export enum Season {
   UNKNOWN = 0,
@@ -12,14 +12,18 @@ export enum Season {
 
 interface AppState {
   seasons: SeasonModel[];
-  lastSync: Date|undefined;
   loadingSeasons: boolean;
+  seriesForSeason: SeriesModel[];
+  loadingSeries: boolean;
+  lastSync: Date|undefined;
 }
 
 export const initialState: AppState = {
   seasons: [],
-  lastSync: undefined,
   loadingSeasons: false,
+  seriesForSeason: [],
+  loadingSeries: false,
+  lastSync: undefined,
 }
 
 export function reducer(state: AppState = initialState, action: AllActions) {
@@ -33,11 +37,19 @@ export function reducer(state: AppState = initialState, action: AllActions) {
         ...state, seasons: action.payload.json,
             lastSync: action.payload.lastSync, loadingSeasons: false,
       }
+    case FETCH_SERIES_START:
+      return {
+        ...state, loadingSeries: true,
+      }
+    case FETCH_SERIES_SUCCESS:
+      return {
+        ...state, seasons: action.payload.json, loadingSeries: false,
+      }
     case SET_SEASON_START_DATE:
-      const index = state.seasons.indexOf(action.payload.season);
+      const seasonIdx = state.seasons.indexOf(action.payload.season);
       return {
         ...state, seasons: state.seasons.map((season, idx) => {
-          if (idx !== index) {
+          if (idx !== seasonIdx) {
             // This isn't the item we care about - keep it as-is
             return season
           }
@@ -46,6 +58,22 @@ export function reducer(state: AppState = initialState, action: AllActions) {
           const startDate = action.payload.startDate;
           return {
             ...season, startDate: startDate ? startDate.getTime() : null,
+          }
+        })
+      }
+    case SET_SERIES_ID:
+      const seriesIdx = state.seriesForSeason.indexOf(action.payload.series);
+      return {
+        ...state, seriesForSeason: state.seriesForSeason.map((series, idx) => {
+          if (idx !== seriesIdx) {
+            // This isn't the item we care about - keep it as-is
+            return series
+          }
+
+          // Otherwise, this is the one we want - return an updated value
+          const seriesId = action.payload.seriesId;
+          return {
+            ...series, idAL: seriesId || null,
           }
         })
       }

--- a/app/src/state/reducer.ts
+++ b/app/src/state/reducer.ts
@@ -43,7 +43,7 @@ export function reducer(state: AppState = initialState, action: AllActions) {
       }
     case FETCH_SERIES_SUCCESS:
       return {
-        ...state, seasons: action.payload.json, loadingSeries: false,
+        ...state, seriesForSeason: action.payload.json, loadingSeries: false,
       }
     case SET_SEASON_START_DATE:
       const seasonIdx = state.seasons.indexOf(action.payload.season);
@@ -73,7 +73,7 @@ export function reducer(state: AppState = initialState, action: AllActions) {
           // Otherwise, this is the one we want - return an updated value
           const seriesId = action.payload.seriesId;
           return {
-            ...series, idAL: seriesId || null,
+            ...series, idAL: seriesId || -1,
           }
         })
       }

--- a/functions/jest.config.js
+++ b/functions/jest.config.js
@@ -5,5 +5,8 @@ module.exports = {
   // github.com/kulshekhar/ts-jest/issues/259#issuecomment-504088010
   maxWorkers: 1,  // speeds up tests
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
-  testEnvironment: 'node'
+  testEnvironment: 'node',
+  setupFiles: [
+    './setupJest.ts',
+  ],
 }

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -1021,6 +1021,14 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.11.tgz",
       "integrity": "sha512-O+x6uIpa6oMNTkPuHDa9MhMMehlxLAd5QcOvKRjAFsBVpeFWTOPnXbDvILvFgFFZfQ1xh1EZi1FbXxUix+zpsQ=="
     },
+    "@types/node-fetch": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.4.tgz",
+      "integrity": "sha512-Oz6id++2qAOFuOlE1j0ouk1dzl3mmI1+qINPNBhi9nt/gVOz0G+13Ao6qjhdF0Ys+eOkhu6JnFmt38bR3H0POQ==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/range-parser": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
@@ -8433,7 +8441,8 @@
     "psl": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
-      "integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw=="
+      "integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw==",
+      "dev": true
     },
     "pump": {
       "version": "3.0.0",
@@ -8492,7 +8501,8 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
     },
     "qs": {
       "version": "6.7.0",
@@ -8709,28 +8719,11 @@
         }
       }
     },
-    "request-promise": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.5.tgz",
-      "integrity": "sha512-ZgnepCykFdmpq86fKGwqntyTiUrHycALuGggpyCZwMvGaZWgxW6yagT0FHkgo5LzYvOaCNvxYwWYIjevSH1EDg==",
-      "requires": {
-        "bluebird": "^3.5.0",
-        "request-promise-core": "1.1.3",
-        "stealthy-require": "^1.1.1",
-        "tough-cookie": "^2.3.3"
-      },
-      "dependencies": {
-        "bluebird": {
-          "version": "3.7.2",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-          "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
-        }
-      }
-    },
     "request-promise-core": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.3.tgz",
       "integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
+      "dev": true,
       "requires": {
         "lodash": "^4.17.15"
       }
@@ -9405,7 +9398,8 @@
     "stealthy-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+      "dev": true
     },
     "stream-events": {
       "version": "1.0.5",
@@ -9967,6 +9961,7 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
       "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "dev": true,
       "requires": {
         "psl": "^1.1.28",
         "punycode": "^2.1.1"

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -893,11 +893,6 @@
         "@babel/types": "^7.3.0"
       }
     },
-    "@types/bluebird": {
-      "version": "3.5.29",
-      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.29.tgz",
-      "integrity": "sha512-kmVtnxTuUuhCET669irqQmPAez4KFnFVKvpleVRyfC3g+SHD1hIkFZcWLim9BVcwUBLO59o8VZE4yGCmTif8Yw=="
-    },
     "@types/body-parser": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.1.tgz",
@@ -920,7 +915,8 @@
     "@types/caseless": {
       "version": "0.12.2",
       "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
-      "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w=="
+      "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==",
+      "dev": true
     },
     "@types/connect": {
       "version": "3.4.32",
@@ -1038,6 +1034,7 @@
       "version": "2.48.3",
       "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.3.tgz",
       "integrity": "sha512-3Wo2jNYwqgXcIz/rrq18AdOZUQB8cQ34CXZo+LUwPJNpvRAL86+Kc2wwI8mqpz9Cr1V+enIox5v+WZhy/p3h8w==",
+      "dev": true,
       "requires": {
         "@types/caseless": "*",
         "@types/node": "*",
@@ -1049,21 +1046,13 @@
           "version": "2.5.1",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
           "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+          "dev": true,
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.6",
             "mime-types": "^2.1.12"
           }
         }
-      }
-    },
-    "@types/request-promise": {
-      "version": "4.1.45",
-      "resolved": "https://registry.npmjs.org/@types/request-promise/-/request-promise-4.1.45.tgz",
-      "integrity": "sha512-KFagTY/a7CzAj86DkhaAtqP0ViYTNam+CfEokSwtPFUIuq9Qrq+Rq2X4nuaB6OJmM2s0xWeiS085Ro7vR0tt9Q==",
-      "requires": {
-        "@types/bluebird": "*",
-        "@types/request": "*"
       }
     },
     "@types/serve-static": {
@@ -1084,7 +1073,8 @@
     "@types/tough-cookie": {
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.5.tgz",
-      "integrity": "sha512-SCcK7mvGi3+ZNz833RRjFIxrn4gI1PPR3NtuIS+6vMkvmsGjosqTJwRt5bAEFLRz+wtJMWv8+uOnZf2hi2QXTg=="
+      "integrity": "sha512-SCcK7mvGi3+ZNz833RRjFIxrn4gI1PPR3NtuIS+6vMkvmsGjosqTJwRt5bAEFLRz+wtJMWv8+uOnZf2hi2QXTg==",
+      "dev": true
     },
     "@types/yargs": {
       "version": "13.0.3",
@@ -1472,7 +1462,8 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
     },
     "atob": {
       "version": "2.1.2",
@@ -2267,6 +2258,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -2907,7 +2899,8 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
     },
     "depd": {
       "version": "1.1.2",

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -6598,6 +6598,24 @@
         "jest-util": "^24.9.0"
       }
     },
+    "jest-fetch-mock": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-2.1.2.tgz",
+      "integrity": "sha512-tcSR4Lh2bWLe1+0w/IwvNxeDocMI/6yIA2bijZ0fyWxC4kQ18lckQ1n7Yd40NKuisGmcGBRFPandRXrW/ti/Bw==",
+      "dev": true,
+      "requires": {
+        "cross-fetch": "^2.2.2",
+        "promise-polyfill": "^7.1.1"
+      },
+      "dependencies": {
+        "promise-polyfill": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-7.1.2.tgz",
+          "integrity": "sha512-FuEc12/eKqqoRYIGBrUptCBRhobL19PS2U31vMNTfyck1FxPyMfgsXyW4Mav85y/ZN1hop3hOwRlUDok23oYfQ==",
+          "dev": true
+        }
+      }
+    },
     "jest-get-type": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.9.0.tgz",

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -893,6 +893,11 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/bluebird": {
+      "version": "3.5.29",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.29.tgz",
+      "integrity": "sha512-kmVtnxTuUuhCET669irqQmPAez4KFnFVKvpleVRyfC3g+SHD1hIkFZcWLim9BVcwUBLO59o8VZE4yGCmTif8Yw=="
+    },
     "@types/body-parser": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.1.tgz",
@@ -915,8 +920,7 @@
     "@types/caseless": {
       "version": "0.12.2",
       "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
-      "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==",
-      "dev": true
+      "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w=="
     },
     "@types/connect": {
       "version": "3.4.32",
@@ -1026,7 +1030,6 @@
       "version": "2.48.3",
       "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.3.tgz",
       "integrity": "sha512-3Wo2jNYwqgXcIz/rrq18AdOZUQB8cQ34CXZo+LUwPJNpvRAL86+Kc2wwI8mqpz9Cr1V+enIox5v+WZhy/p3h8w==",
-      "dev": true,
       "requires": {
         "@types/caseless": "*",
         "@types/node": "*",
@@ -1038,13 +1041,21 @@
           "version": "2.5.1",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
           "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
-          "dev": true,
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.6",
             "mime-types": "^2.1.12"
           }
         }
+      }
+    },
+    "@types/request-promise": {
+      "version": "4.1.45",
+      "resolved": "https://registry.npmjs.org/@types/request-promise/-/request-promise-4.1.45.tgz",
+      "integrity": "sha512-KFagTY/a7CzAj86DkhaAtqP0ViYTNam+CfEokSwtPFUIuq9Qrq+Rq2X4nuaB6OJmM2s0xWeiS085Ro7vR0tt9Q==",
+      "requires": {
+        "@types/bluebird": "*",
+        "@types/request": "*"
       }
     },
     "@types/serve-static": {
@@ -1065,8 +1076,7 @@
     "@types/tough-cookie": {
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.5.tgz",
-      "integrity": "sha512-SCcK7mvGi3+ZNz833RRjFIxrn4gI1PPR3NtuIS+6vMkvmsGjosqTJwRt5bAEFLRz+wtJMWv8+uOnZf2hi2QXTg==",
-      "dev": true
+      "integrity": "sha512-SCcK7mvGi3+ZNz833RRjFIxrn4gI1PPR3NtuIS+6vMkvmsGjosqTJwRt5bAEFLRz+wtJMWv8+uOnZf2hi2QXTg=="
     },
     "@types/yargs": {
       "version": "13.0.3",
@@ -1454,8 +1464,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "atob": {
       "version": "2.1.2",
@@ -2250,7 +2259,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -2891,8 +2899,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "depd": {
       "version": "1.1.2",
@@ -8426,8 +8433,7 @@
     "psl": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
-      "integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw==",
-      "dev": true
+      "integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw=="
     },
     "pump": {
       "version": "3.0.0",
@@ -8486,8 +8492,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qs": {
       "version": "6.7.0",
@@ -8704,11 +8709,28 @@
         }
       }
     },
+    "request-promise": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.5.tgz",
+      "integrity": "sha512-ZgnepCykFdmpq86fKGwqntyTiUrHycALuGggpyCZwMvGaZWgxW6yagT0FHkgo5LzYvOaCNvxYwWYIjevSH1EDg==",
+      "requires": {
+        "bluebird": "^3.5.0",
+        "request-promise-core": "1.1.3",
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
+      },
+      "dependencies": {
+        "bluebird": {
+          "version": "3.7.2",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+          "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+        }
+      }
+    },
     "request-promise-core": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.3.tgz",
       "integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
-      "dev": true,
       "requires": {
         "lodash": "^4.17.15"
       }
@@ -9383,8 +9405,7 @@
     "stealthy-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
-      "dev": true
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
     "stream-events": {
       "version": "1.0.5",
@@ -9946,7 +9967,6 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
       "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "dev": true,
       "requires": {
         "psl": "^1.1.28",
         "punycode": "^2.1.1"

--- a/functions/package.json
+++ b/functions/package.json
@@ -34,6 +34,7 @@
     "firebase-functions-test": "^0.1.7",
     "firebase-tools": "^7.8.1",
     "jest": "^24.9.0",
+    "jest-fetch-mock": "^2.1.2",
     "jest-mock": "^24.9.0",
     "ts-jest": "^24.2.0",
     "tslint": "^5.20.1",

--- a/functions/package.json
+++ b/functions/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@types/cors": "^2.8.6",
     "@types/node": "^12.12.11",
+    "@types/node-fetch": "^2.5.4",
     "@types/request-promise": "^4.1.45",
     "cors": "^2.8.5",
     "firebase-admin": "^8.8.0",
@@ -28,7 +29,7 @@
     "googleapis": "^45.0.0",
     "graphql-request": "^1.8.2",
     "node": "^8.13.0",
-    "request-promise": "^4.2.5"
+    "node-fetch": "^2.6.0"
   },
   "devDependencies": {
     "@firebase/testing": "^0.16.0",

--- a/functions/package.json
+++ b/functions/package.json
@@ -21,7 +21,6 @@
     "@types/cors": "^2.8.6",
     "@types/node": "^12.12.11",
     "@types/node-fetch": "^2.5.4",
-    "@types/request-promise": "^4.1.45",
     "cors": "^2.8.5",
     "firebase-admin": "^8.8.0",
     "firebase-functions": "^3.3.0",

--- a/functions/package.json
+++ b/functions/package.json
@@ -20,13 +20,15 @@
   "dependencies": {
     "@types/cors": "^2.8.6",
     "@types/node": "^12.12.11",
+    "@types/request-promise": "^4.1.45",
     "cors": "^2.8.5",
     "firebase-admin": "^8.8.0",
     "firebase-functions": "^3.3.0",
     "gaxios": "^2.1.0",
     "googleapis": "^45.0.0",
     "graphql-request": "^1.8.2",
-    "node": "^8.13.0"
+    "node": "^8.13.0",
+    "request-promise": "^4.2.5"
   },
   "devDependencies": {
     "@firebase/testing": "^0.16.0",

--- a/functions/setupJest.ts
+++ b/functions/setupJest.ts
@@ -1,0 +1,5 @@
+import {GlobalWithFetchMock} from 'jest-fetch-mock';
+
+const customGlobal: GlobalWithFetchMock = global as GlobalWithFetchMock;
+customGlobal.fetch = require('jest-fetch-mock');
+customGlobal.fetchMock = customGlobal.fetch;

--- a/functions/setupJest.ts
+++ b/functions/setupJest.ts
@@ -1,5 +1,6 @@
-import {GlobalWithFetchMock} from 'jest-fetch-mock';
+// tslint:disable-next-line: no-import-side-effect
+import 'jest';
 
-const customGlobal: GlobalWithFetchMock = global as GlobalWithFetchMock;
-customGlobal.fetch = require('jest-fetch-mock');
-customGlobal.fetchMock = customGlobal.fetch;
+const fetch = require('jest-fetch-mock');
+
+jest.setMock('node-fetch', fetch);

--- a/functions/src/getAllSeasons.test.ts
+++ b/functions/src/getAllSeasons.test.ts
@@ -35,7 +35,7 @@ describe('getAllSeasons', () => {
 
     expect(res.statusCode).toEqual(200);
     expect(res.body!.seasons.length).toEqual(2);
-    expect(res.body!.lastSyncMs).toEqual(1574413847579);
+    expect(res.body!.lastSyncMs).toEqual(1575513546186);
   });
 
   test('should undefined for last sync if it is missing', async () => {

--- a/functions/src/getSeries.f.ts
+++ b/functions/src/getSeries.f.ts
@@ -19,8 +19,8 @@ const cors = Cors({
 export const getSeries = functions.https.onRequest((req, res) => {
   return cors(req, res, async () => {
     const query: GetAllSeriesRequest = req.query;
-    console.log(JSON.stringify(query));
     const {seasonId} = query;
+
     try {
       let seriesList: SeriesModel[];
       if (seasonId) {

--- a/functions/src/getSeries.f.ts
+++ b/functions/src/getSeries.f.ts
@@ -18,8 +18,9 @@ const cors = Cors({
  */
 export const getSeries = functions.https.onRequest((req, res) => {
   return cors(req, res, async () => {
-    const reqBody: GetAllSeriesRequest = req.body;
-    const {seasonId} = reqBody;
+    const query: GetAllSeriesRequest = req.query;
+    console.log(JSON.stringify(query));
+    const {seasonId} = query;
     try {
       let seriesList: SeriesModel[];
       if (seasonId) {

--- a/functions/src/getSeries.test.ts
+++ b/functions/src/getSeries.test.ts
@@ -38,8 +38,8 @@ describe('getSeries', () => {
   });
 
   test('should return all series for a given seasonId', async () => {
-    const req = new MockRequest<GetAllSeriesRequest>().setMethod('GET').setBody(
-        {seasonId: 281991772});  // WINTER 2018
+    const req = new MockRequest<GetAllSeriesRequest>();
+    req.setMethod('GET').setQuery({seasonId: 281991772});  // WINTER 2018
     const res = new MockResponse<GetAllSeriesResponse>();
 
     getSeries(
@@ -52,8 +52,8 @@ describe('getSeries', () => {
   });
 
   test('should return an empty list for an invalid seasonId', async () => {
-    const req = new MockRequest<GetAllSeriesRequest>().setMethod('GET').setBody(
-        {seasonId: 12345});
+    const req = new MockRequest<GetAllSeriesRequest>();
+    req.setMethod('GET').setQuery({seasonId: 12345});
     const res = new MockResponse<GetAllSeriesResponse>();
 
     getSeries(

--- a/functions/src/helpers/testing/mockAnilistQueryMediaResponse.ts
+++ b/functions/src/helpers/testing/mockAnilistQueryMediaResponse.ts
@@ -1,0 +1,15 @@
+/** Saved response from AniList.co query Media api */
+export const mockAnilistQueryMediaResponse = {
+  'data': {
+    'Media': {
+      'title':
+          {'romaji': 'Teekyuu', 'english': 'Teekyuu', 'native': 'てーきゅう'},
+      'id': 15125,
+      'idMal': 15125,
+      'format': 'TV_SHORT',
+      'episodes': 12,
+      'season': 'FALL',
+      'seasonInt': 124
+    }
+  }
+};

--- a/functions/src/helpers/upsertDevMetadata.ts
+++ b/functions/src/helpers/upsertDevMetadata.ts
@@ -37,6 +37,25 @@ export function getUpsertSheetMetadata(
   });
 }
 
+/** Convenience wrapper to upsert metadata on a specific sheet row. */
+export function getUpsertSheetRowMetadata(
+    api: sheets_v4.Sheets, sheetId: number, row: number, key: string,
+    value: string) {
+  return getUpsertMetadataRequest(api, {
+    spreadsheetId: SPREADSHEET_ID,
+    metadataKey: key,
+    metadataValue: value,
+    location: {
+      sheetId,
+      dimensionRange: {
+        startIndex: row,
+        endIndex: row + 1,
+      }
+    },
+    visibility: 'PROJECT',
+  });
+}
+
 /**
  * Implements Upsert sementics for developer metadata. First queries for the
  * metadata by key and location and updates it if found. If not creates a new

--- a/functions/src/helpers/upsertDevMetadata.ts
+++ b/functions/src/helpers/upsertDevMetadata.ts
@@ -46,8 +46,9 @@ export function getUpsertSheetRowMetadata(
     metadataKey: key,
     metadataValue: value,
     location: {
-      sheetId,
       dimensionRange: {
+        sheetId,
+        dimension: 'ROWS',
         startIndex: row,
         endIndex: row + 1,
       }

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -11,11 +11,13 @@ admin.initializeApp({
 import {getAllSeasons} from './getAllSeasons.f';
 import {getSeries} from './getSeries.f';
 import {setSeasonStartDate} from './setSeasonStartDate.f';
+import {setSeriesId} from './setSeriesId.f';
 import {syncFromVotingSheet} from './syncFromVotingSheet.f';
 
 export {
   getAllSeasons,
   getSeries,
   setSeasonStartDate,
+  setSeriesId,
   syncFromVotingSheet,
 };

--- a/functions/src/setSeasonStartDate.test.ts
+++ b/functions/src/setSeasonStartDate.test.ts
@@ -23,11 +23,11 @@ import {START_DATE_METADATA_KEY} from './model/sheets';
 
 describe('setSeasonStartDate', () => {
   beforeEach(async () => {
-    await firebase.clearFirestoreData({projectId: PROJECT_ID});
     await loadTestDataToFirestore();
   });
-  afterEach(() => {
+  afterEach(async () => {
     testEnv.cleanup();
+    await firebase.clearFirestoreData({projectId: PROJECT_ID});
   });
 
   test('should return a 400 if startDate missing', async () => {

--- a/functions/src/setSeasonStartDate.test.ts
+++ b/functions/src/setSeasonStartDate.test.ts
@@ -21,7 +21,6 @@ import {loadTestDataToFirestore} from './testing/loadTestData';
 import {mockSetStartDateMetadataResponse} from './helpers/testing/mockSetStartDateResponse';
 import {START_DATE_METADATA_KEY} from './model/sheets';
 
-
 describe('setSeasonStartDate', () => {
   beforeEach(async () => {
     await firebase.clearFirestoreData({projectId: PROJECT_ID});

--- a/functions/src/setSeriesId.f.ts
+++ b/functions/src/setSeriesId.f.ts
@@ -27,13 +27,49 @@ export const setSeriesId = functions.https.onRequest((req, res) => {
       return;
     }
 
+    // Here we define our query as a multi-line string
+    // Storing it in a separate .graphql/.gql file is also possible
+    const query = `
+query ($id: Int) {
+  Media (id: $id, type: ANIME) {
+    title {
+      romaji
+      english
+      native
+    }
+    id
+    idMal
+    format
+    episodes
+    season
+    seasonInt
+  }
+}
+`;
+
+    // Define our query variables and values that will be used in the query
+    // request
+    const variables = {id: seriesId};
+
+    // Define the config we'll need for our Api request
+    const url = 'https://graphql.anilist.co', options = {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+      },
+      body: JSON.stringify({query: query, variables: variables})
+    };
+
     try {
+      // Make the HTTP Api request
+      const data = await fetch(url, options).then(resp => resp.json());
       const payload: SetSeriesIdResponse = {
-        data: req.body,
+        data: data,
       };
       res.status(200).send(payload);
     } catch (err) {
-      res.status(err.status).send({err});
+      res.status(500).send({err});
     }
   });
 });

--- a/functions/src/setSeriesId.f.ts
+++ b/functions/src/setSeriesId.f.ts
@@ -1,7 +1,7 @@
 import Cors from 'cors';
 import admin from 'firebase-admin';
 import * as functions from 'firebase-functions';
-import requestPromise from 'request-promise';
+import fetch from 'node-fetch';
 
 import {SCOPES, SPREADSHEET_ID} from './config';
 import {getSheetsClient} from './google.auth';
@@ -73,8 +73,8 @@ query ($id: Int) {
     let data: any;
     try {
       // Make the HTTP Api request
-      const alResp = await requestPromise(url, options);
-      data = JSON.parse(alResp);
+      const alResp = await fetch(url, options);
+      data = await alResp.json();
     } catch (e) {
       console.log(e);
       res.status(500).send({err: e});

--- a/functions/src/setSeriesId.f.ts
+++ b/functions/src/setSeriesId.f.ts
@@ -5,7 +5,7 @@ import {SCOPES, SPREADSHEET_ID} from './config';
 import {getSheetsClient} from './google.auth';
 import {getUpsertSheetRowMetadata} from './helpers/upsertDevMetadata';
 import {SetSeriesIdRequest, SetSeriesIdResponse} from './model/service';
-import {SERIES_AL_ID_KEY} from './model/sheets';
+import {SERIES_AL_ID_KEY, SeriesMetadataPayload} from './model/sheets';
 
 const cors = Cors({
   origin: true,
@@ -70,8 +70,17 @@ query ($id: Int) {
       const data = await fetch(url, options).then(resp => resp.json());
 
       const api = await getSheetsClient(SCOPES);
+
+      const metadataPayload: SeriesMetadataPayload = {
+        titleEn: data.data.Media.title.english,
+        alId: data.data.Media.id,
+        malId: data.data.Media.idMal,
+        type: data.data.Media.format,
+        episodes: data.data.Media.episodes,
+      };
       const sheetsReqs = await getUpsertSheetRowMetadata(
-          api, seasonId, row, SERIES_AL_ID_KEY, String(data.data.Media.id));
+          api, seasonId, row, SERIES_AL_ID_KEY,
+          JSON.stringify(metadataPayload));
 
       const request = api.spreadsheets.batchUpdate({
         spreadsheetId: SPREADSHEET_ID,

--- a/functions/src/setSeriesId.f.ts
+++ b/functions/src/setSeriesId.f.ts
@@ -1,0 +1,39 @@
+import Cors from 'cors';
+import * as functions from 'firebase-functions';
+
+import {SetSeriesIdRequest, SetSeriesIdResponse} from './model/service';
+
+const cors = Cors({
+  origin: true,
+});
+
+export const setSeriesId = functions.https.onRequest((req, res) => {
+  return cors(req, res, async () => {
+    const reqBody: SetSeriesIdRequest = req.body;
+    const {seasonId, row, seriesId} = reqBody;
+
+    if (!seasonId) {
+      res.status(400).send({err: 'seasonId must be set and a number'});
+      return;
+    }
+
+    if (!row) {
+      res.status(400).send({err: 'row must be set and a number'});
+      return;
+    }
+
+    if (!seriesId) {
+      res.status(400).send({err: 'seriesId must be set and a number'});
+      return;
+    }
+
+    try {
+      const payload: SetSeriesIdResponse = {
+        data: req.body,
+      };
+      res.status(200).send(payload);
+    } catch (err) {
+      res.status(err.status).send({err});
+    }
+  });
+});

--- a/functions/src/setSeriesId.test.ts
+++ b/functions/src/setSeriesId.test.ts
@@ -1,15 +1,17 @@
 // tslint:disable-next-line: no-import-side-effect
 import 'jest';
-import 'jest-fetch-mock';
 
 import * as firebase from '@firebase/testing';
 import admin from 'firebase-admin';
 import * as functions from 'firebase-functions';
 import functionsTest from 'firebase-functions-test';
+import {GlobalWithFetchMock} from 'jest-fetch-mock';
 
 import {PROJECT_ID} from './config';
 import {SetSeriesIdRequest, SetSeriesIdResponse} from './model/service';
 import {MockRequest, MockResponse} from './testing/express-helpers';
+
+const {fetchMock} = global as GlobalWithFetchMock;
 
 const testEnv = functionsTest({projectId: PROJECT_ID});
 admin.initializeApp({
@@ -24,7 +26,7 @@ describe('setSeriesId', () => {
   });
   afterEach(async () => {
     testEnv.cleanup();
-    fetch.resetMocks();
+    fetchMock.resetMocks();
     await firebase.clearFirestoreData({projectId: PROJECT_ID});
   });
 
@@ -73,6 +75,8 @@ describe('setSeriesId', () => {
   });
 
   test('should query AniList', async () => {
+    fetchMock.mockResponseOnce(
+        JSON.stringify({data: {Media: {title: {romaji: 'Teekyuu'}}}}));
     const req = new MockRequest<SetSeriesIdRequest>().setMethod('GET').setBody({
       seasonId: 12345,
       row: 1,

--- a/functions/src/setSeriesId.test.ts
+++ b/functions/src/setSeriesId.test.ts
@@ -1,5 +1,6 @@
 // tslint:disable-next-line: no-import-side-effect
 import 'jest';
+import 'jest-fetch-mock';
 
 import * as firebase from '@firebase/testing';
 import admin from 'firebase-admin';
@@ -23,6 +24,7 @@ describe('setSeriesId', () => {
   });
   afterEach(async () => {
     testEnv.cleanup();
+    fetch.resetMocks();
     await firebase.clearFirestoreData({projectId: PROJECT_ID});
   });
 

--- a/functions/src/setSeriesId.test.ts
+++ b/functions/src/setSeriesId.test.ts
@@ -17,7 +17,6 @@ admin.initializeApp({
 import {setSeriesId} from './setSeriesId.f';
 import {loadTestDataToFirestore} from './testing/loadTestData';
 
-
 describe('setSeriesId', () => {
   beforeEach(async () => {
     await loadTestDataToFirestore();
@@ -69,5 +68,28 @@ describe('setSeriesId', () => {
 
     expect(res.statusCode).toEqual(400);
     expect(res.body!.err).toEqual('seriesId must be set and a number');
+  });
+
+  test('should query AniList', async () => {
+    const req = new MockRequest<SetSeriesIdRequest>().setMethod('GET').setBody({
+      seasonId: 12345,
+      row: 1,
+      seriesId: 15125,  // Teekyu
+    });
+    const res = new MockResponse<SetSeriesIdResponse>();
+
+    setSeriesId(
+        req as unknown as functions.Request,
+        res as unknown as functions.Response);
+    await res.sent;
+
+    expect(res.statusCode).toEqual(200);
+    expect(res.body!.data).toMatchObject({
+      data: {
+        Media: {
+          title: {romaji: 'Teekyuu'},
+        },
+      }
+    });
   });
 });

--- a/functions/src/setSeriesId.test.ts
+++ b/functions/src/setSeriesId.test.ts
@@ -1,0 +1,73 @@
+// tslint:disable-next-line: no-import-side-effect
+import 'jest';
+
+import * as firebase from '@firebase/testing';
+import admin from 'firebase-admin';
+import * as functions from 'firebase-functions';
+import functionsTest from 'firebase-functions-test';
+
+import {PROJECT_ID} from './config';
+import {SetSeriesIdRequest, SetSeriesIdResponse} from './model/service';
+import {MockRequest, MockResponse} from './testing/express-helpers';
+
+const testEnv = functionsTest({projectId: PROJECT_ID});
+admin.initializeApp({
+  credential: admin.credential.applicationDefault(),
+});
+import {setSeriesId} from './setSeriesId.f';
+import {loadTestDataToFirestore} from './testing/loadTestData';
+
+
+describe('setSeriesId', () => {
+  beforeEach(async () => {
+    await loadTestDataToFirestore();
+  });
+  afterEach(async () => {
+    testEnv.cleanup();
+    await firebase.clearFirestoreData({projectId: PROJECT_ID});
+  });
+
+  test('should return a 400 if seasonId missing', async () => {
+    const req = new MockRequest<SetSeriesIdRequest>().setMethod('GET');
+    const res = new MockResponse<SetSeriesIdResponse>();
+
+    setSeriesId(
+        req as unknown as functions.Request,
+        res as unknown as functions.Response);
+    await res.sent;
+
+    expect(res.statusCode).toEqual(400);
+    expect(res.body!.err).toEqual('seasonId must be set and a number');
+  });
+
+  test('should return a 400 if row missing', async () => {
+    const req = new MockRequest<SetSeriesIdRequest>().setMethod('GET').setBody({
+      seasonId: 12345,
+    });
+    const res = new MockResponse<SetSeriesIdResponse>();
+
+    setSeriesId(
+        req as unknown as functions.Request,
+        res as unknown as functions.Response);
+    await res.sent;
+
+    expect(res.statusCode).toEqual(400);
+    expect(res.body!.err).toEqual('row must be set and a number');
+  });
+
+  test('should return a 400 if seriesId missing', async () => {
+    const req = new MockRequest<SetSeriesIdRequest>().setMethod('GET').setBody({
+      seasonId: 12345,
+      row: 1,
+    });
+    const res = new MockResponse<SetSeriesIdResponse>();
+
+    setSeriesId(
+        req as unknown as functions.Request,
+        res as unknown as functions.Response);
+    await res.sent;
+
+    expect(res.statusCode).toEqual(400);
+    expect(res.body!.err).toEqual('seriesId must be set and a number');
+  });
+});

--- a/functions/src/setSeriesId.test.ts
+++ b/functions/src/setSeriesId.test.ts
@@ -11,7 +11,7 @@ import {GlobalWithFetchMock} from 'jest-fetch-mock';
 import {PROJECT_ID, SPREADSHEET_ID} from './config';
 import {mockAnilistQueryMediaResponse} from './helpers/testing/mockAnilistQueryMediaResponse';
 import {SetSeriesIdRequest, SetSeriesIdResponse} from './model/service';
-import {SERIES_AL_ID_KEY} from './model/sheets';
+import {SERIES_AL_ID_KEY, SeriesMetadataPayload} from './model/sheets';
 import {MockRequest, MockResponse} from './testing/express-helpers';
 
 const {fetchMock} = global as GlobalWithFetchMock;
@@ -22,6 +22,7 @@ admin.initializeApp({
 });
 import {setSeriesId} from './setSeriesId.f';
 import {loadTestDataToFirestore} from './testing/loadTestData';
+import { SeriesType } from './model/firestore';
 
 describe('setSeriesId', () => {
   beforeEach(async () => {
@@ -110,6 +111,13 @@ describe('setSeriesId', () => {
         res as unknown as functions.Response);
     await res.sent;
 
+    const expectedPayload: SeriesMetadataPayload = {
+      titleEn: 'Teekyuu',
+      alId: 15125,
+      malId: 15125,
+      type: SeriesType.Short,
+      episodes: 12,
+    }
     expect(google.sheets({version: 'v4'}).spreadsheets.batchUpdate)
         .toHaveBeenCalledWith<
             sheets_v4.Params$Resource$Spreadsheets$Batchupdate[]>({
@@ -119,7 +127,7 @@ describe('setSeriesId', () => {
               createDeveloperMetadata: {
                 developerMetadata: {
                   metadataKey: SERIES_AL_ID_KEY,
-                  metadataValue: '15125',
+                  metadataValue: JSON.stringify(expectedPayload),
                   location: {
                     sheetId: 12345,
                     dimensionRange: {

--- a/functions/src/setSeriesId.test.ts
+++ b/functions/src/setSeriesId.test.ts
@@ -6,15 +6,14 @@ import admin from 'firebase-admin';
 import * as functions from 'firebase-functions';
 import functionsTest from 'firebase-functions-test';
 import {google, sheets_v4} from 'googleapis';
-import {GlobalWithFetchMock} from 'jest-fetch-mock';
+import {FetchMock} from 'jest-fetch-mock';
+const fetchMock: FetchMock = require('node-fetch');
 
 import {PROJECT_ID, SPREADSHEET_ID} from './config';
 import {mockAnilistQueryMediaResponse} from './helpers/testing/mockAnilistQueryMediaResponse';
 import {SetSeriesIdRequest, SetSeriesIdResponse} from './model/service';
 import {SERIES_AL_ID_KEY, SeriesMetadataPayload} from './model/sheets';
 import {MockRequest, MockResponse} from './testing/express-helpers';
-
-const {fetchMock} = global as GlobalWithFetchMock;
 
 const testEnv = functionsTest({projectId: PROJECT_ID});
 admin.initializeApp({
@@ -128,8 +127,9 @@ describe('setSeriesId', () => {
                   metadataKey: SERIES_AL_ID_KEY,
                   metadataValue: JSON.stringify(expectedPayload),
                   location: {
-                    sheetId: 1242888778,
                     dimensionRange: {
+                      sheetId: 1242888778,
+                      dimension: 'ROWS',
                       startIndex: 1,
                       endIndex: 2,
                     },

--- a/functions/src/syncFromVotingSheet.f.ts
+++ b/functions/src/syncFromVotingSheet.f.ts
@@ -44,13 +44,12 @@ export const syncFromVotingSheet = functions.https.onRequest(async (_, res) => {
       const seasonRef = seasonCollection.doc(String(season.sheetId));
       batch.set(seasonRef, season);
 
-      for (const series of seriesList) {
-        // TODO: Need to find a stable ID for the series so updates are
-        // itempotent. Maybe drop all records that don't have an Anilist ID in
-        // the metadata (use that as the stable id).
-        const seriesRef = seasonRef.collection(SERIES_COLLECTION).doc();
+      seriesList.forEach((series, index) => {
+        // Using seasonId + index as a stable ID
+        const seriesRef = seasonRef.collection(SERIES_COLLECTION)
+                              .doc(season.sheetId + '-' + index);
         batch.set(seriesRef, series);
-      }
+      });
     }
 
     // Record the timestamp of the latest sync

--- a/functions/src/testing/dumpTestData.ts
+++ b/functions/src/testing/dumpTestData.ts
@@ -30,7 +30,8 @@ export interface DocumentModel {
  * more collection types.
  */
 async function dumpTestDataToFile() {
-  const dataFile = path.resolve(__dirname, './test-data/firestore.json');
+  const dataFile =
+      path.resolve(__dirname, '../../src/testing/test-data/firestore.json');
 
   const configSnap = await firestore.collection(CONFIG_COLLECTION).get();
   const configData = snapshotToJson(CONFIG_COLLECTION, configSnap);

--- a/functions/src/testing/express-helpers.ts
+++ b/functions/src/testing/express-helpers.ts
@@ -9,6 +9,7 @@ export class MockRequest<T> {
   method: MethodType = 'GET';
   headers: {[header: string]: string} = {};
   body?: T = {} as T;  // TODO: Convenient but might not be safe in all cases
+  query? = {};         // For GET query params
 
   setMethod(method: MethodType) {
     this.method = method;
@@ -23,6 +24,10 @@ export class MockRequest<T> {
   }
   setBody(payload: T) {
     this.body = payload;
+    return this;
+  }
+  setQuery(queryParams: {}) {
+    this.query = queryParams;
     return this;
   }
 }

--- a/functions/src/testing/test-data/firestore.json
+++ b/functions/src/testing/test-data/firestore.json
@@ -2,7 +2,7 @@
   {
     "id": "config/sync-status",
     "data": {
-      "lastSync": 1574413847579
+      "lastSync": 1575513546186
     }
   },
   {
@@ -12,7 +12,7 @@
       "formattedName": "SPRING 2018",
       "sheetId": 1242888778,
       "season": 1,
-      "startDate": 1573686420000
+      "startDate": 1573600020000
     }
   },
   {
@@ -22,310 +22,11 @@
       "formattedName": "WINTER 2018",
       "sheetId": 281991772,
       "season": 4,
-      "startDate": 1573686420000
+      "startDate": 1573600020000
     }
   },
   {
-    "id": "seasons/1242888778/series/17keqGTcVEyuXGee2XZI",
-    "data": {
-      "votingStatus": 0,
-      "votingRecord": [
-        {
-          "votesAgainst": -1,
-          "episodeNum": -1,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": -1
-        },
-        {
-          "votesAgainst": 5,
-          "episodeNum": 1,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": 4
-        }
-      ],
-      "type": "Unknown",
-      "titleEn": "Persona 5 the Animation",
-      "seasonId": null,
-      "episodes": -1
-    }
-  },
-  {
-    "id": "seasons/1242888778/series/1omHdjdDCF6FxEi0JsTQ",
-    "data": {
-      "votingStatus": 0,
-      "votingRecord": [
-        {
-          "votesAgainst": -1,
-          "episodeNum": -1,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": -1
-        },
-        {
-          "votesAgainst": 6,
-          "episodeNum": 1,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": 3
-        }
-      ],
-      "type": "Unknown",
-      "titleEn": "Last Period: Owarinaki Rasen no Monogatari",
-      "seasonId": null,
-      "episodes": -1
-    }
-  },
-  {
-    "id": "seasons/1242888778/series/39kxGfXm5k6by7TU2CNG",
-    "data": {
-      "votingStatus": 0,
-      "votingRecord": [
-        {
-          "votesAgainst": -1,
-          "episodeNum": -1,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": -1
-        },
-        {
-          "votesAgainst": 1,
-          "episodeNum": 1,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": 6
-        },
-        {
-          "votesAgainst": 3,
-          "episodeNum": 2,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": 7
-        },
-        {
-          "votesAgainst": 4,
-          "episodeNum": 3,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": 4
-        },
-        {
-          "votesAgainst": 2,
-          "episodeNum": 4,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": 4
-        }
-      ],
-      "type": "Unknown",
-      "titleEn": "Wotakoi",
-      "seasonId": null,
-      "episodes": -1
-    }
-  },
-  {
-    "id": "seasons/1242888778/series/FMM2Huo3nUVBHcNQYOLk",
-    "data": {
-      "votingStatus": 0,
-      "votingRecord": [
-        {
-          "votesAgainst": -1,
-          "episodeNum": -1,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": -1
-        },
-        {
-          "votesAgainst": 4,
-          "episodeNum": 1,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": 4
-        },
-        {
-          "votesAgainst": 3,
-          "episodeNum": 2,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": 7
-        },
-        {
-          "votesAgainst": 3,
-          "episodeNum": 3,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": 5
-        },
-        {
-          "votesAgainst": 2,
-          "episodeNum": 4,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": 2
-        }
-      ],
-      "type": "Unknown",
-      "titleEn": "Golden Kamuy",
-      "seasonId": null,
-      "episodes": -1
-    }
-  },
-  {
-    "id": "seasons/1242888778/series/Lk2w1nKakc0yxLg9duPr",
-    "data": {
-      "votingStatus": 0,
-      "votingRecord": [
-        {
-          "votesAgainst": 3,
-          "episodeNum": 1,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": 5
-        },
-        {
-          "votesAgainst": -1,
-          "episodeNum": -1,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": -1
-        }
-      ],
-      "type": "Unknown",
-      "titleEn": "Gurazeni",
-      "seasonId": null,
-      "episodes": -1
-    }
-  },
-  {
-    "id": "seasons/1242888778/series/VR9C7JRwlTucnO48HypT",
-    "data": {
-      "votingStatus": 0,
-      "votingRecord": [
-        {
-          "votesAgainst": -1,
-          "episodeNum": -1,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": -1
-        },
-        {
-          "votesAgainst": 3,
-          "episodeNum": 1,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": 4
-        },
-        {
-          "votesAgainst": 5,
-          "episodeNum": 2,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": 4
-        }
-      ],
-      "type": "Unknown",
-      "titleEn": "Gegege no Kitaro (2018)",
-      "seasonId": null,
-      "episodes": -1
-    }
-  },
-  {
-    "id": "seasons/1242888778/series/Vaen3KIewT3yZX47PpBW",
-    "data": {
-      "votingStatus": 0,
-      "votingRecord": [
-        {
-          "votesAgainst": -1,
-          "episodeNum": -1,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": -1
-        },
-        {
-          "votesAgainst": 3,
-          "episodeNum": 1,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": 5
-        },
-        {
-          "votesAgainst": 0,
-          "episodeNum": 2,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": 8
-        },
-        {
-          "votesAgainst": 2,
-          "episodeNum": 3,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": 6
-        },
-        {
-          "votesAgainst": 0,
-          "episodeNum": 4,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": 5
-        }
-      ],
-      "type": "Unknown",
-      "titleEn": "Hinamatsuri",
-      "seasonId": null,
-      "episodes": -1
-    }
-  },
-  {
-    "id": "seasons/1242888778/series/eEdyGdIQlPCCuY5RjS0C",
-    "data": {
-      "votingStatus": 0,
-      "votingRecord": [
-        {
-          "votesAgainst": 2,
-          "episodeNum": 1,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": 4
-        },
-        {
-          "votesAgainst": -1,
-          "episodeNum": -1,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": -1
-        },
-        {
-          "votesAgainst": 2,
-          "episodeNum": 2,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": 7
-        },
-        {
-          "votesAgainst": 1,
-          "episodeNum": 3,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": 6
-        },
-        {
-          "votesAgainst": 1,
-          "episodeNum": 4,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": 5
-        }
-      ],
-      "type": "Unknown",
-      "titleEn": "Megalo Box",
-      "seasonId": null,
-      "episodes": -1
-    }
-  },
-  {
-    "id": "seasons/1242888778/series/jJcyxPTRHjZTzNiVvzr1",
+    "id": "seasons/1242888778/series/1242888778-0",
     "data": {
       "votingStatus": 0,
       "votingRecord": [
@@ -372,45 +73,12 @@
     }
   },
   {
-    "id": "seasons/1242888778/series/jgAbN5gilcElajYQhR1p",
+    "id": "seasons/1242888778/series/1242888778-1",
     "data": {
       "votingStatus": 0,
       "votingRecord": [
         {
-          "votesAgainst": 4,
-          "episodeNum": 1,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": 4
-        },
-        {
-          "votesAgainst": -1,
-          "episodeNum": -1,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": -1
-        },
-        {
-          "votesAgainst": 7,
-          "episodeNum": 2,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": 3
-        }
-      ],
-      "type": "Unknown",
-      "titleEn": "Ginga Eiyuu Densetsu: Die Neue These - Kaikou",
-      "seasonId": null,
-      "episodes": -1
-    }
-  },
-  {
-    "id": "seasons/1242888778/series/l1eKL2rJSTz3H2vmyKvq",
-    "data": {
-      "votingStatus": 0,
-      "votingRecord": [
-        {
-          "votesAgainst": 4,
+          "votesAgainst": 5,
           "episodeNum": 1,
           "seriesId": -1,
           "weekNum": -1,
@@ -418,13 +86,13 @@
         }
       ],
       "type": "Unknown",
-      "titleEn": "Uma Musume: Pretty Derby",
+      "titleEn": "Mahou Shoujo Ore",
       "seasonId": null,
       "episodes": -1
     }
   },
   {
-    "id": "seasons/1242888778/series/nIfK28qIJ21dUm9sGryV",
+    "id": "seasons/1242888778/series/1242888778-10",
     "data": {
       "votingStatus": 0,
       "votingRecord": [
@@ -457,7 +125,7 @@
     }
   },
   {
-    "id": "seasons/1242888778/series/oVRoDZjWiz4avnCm7oWv",
+    "id": "seasons/1242888778/series/1242888778-11",
     "data": {
       "votingStatus": 0,
       "votingRecord": [
@@ -490,26 +158,7 @@
     }
   },
   {
-    "id": "seasons/1242888778/series/tX6ADylxNGvVBjh4Zgen",
-    "data": {
-      "votingStatus": 0,
-      "votingRecord": [
-        {
-          "votesAgainst": 5,
-          "episodeNum": 1,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": 3
-        }
-      ],
-      "type": "Unknown",
-      "titleEn": "Mahou Shoujo Site",
-      "seasonId": null,
-      "episodes": -1
-    }
-  },
-  {
-    "id": "seasons/1242888778/series/v9VH24qapaqxYSN4VDqJ",
+    "id": "seasons/1242888778/series/1242888778-12",
     "data": {
       "votingStatus": 0,
       "votingRecord": [
@@ -556,7 +205,80 @@
     }
   },
   {
-    "id": "seasons/1242888778/series/vY89QK5AeeZLB9LnMgd6",
+    "id": "seasons/1242888778/series/1242888778-13",
+    "data": {
+      "votingStatus": 0,
+      "votingRecord": [
+        {
+          "votesAgainst": -1,
+          "episodeNum": -1,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": -1
+        },
+        {
+          "votesAgainst": 4,
+          "episodeNum": 1,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": 4
+        },
+        {
+          "votesAgainst": 3,
+          "episodeNum": 2,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": 7
+        },
+        {
+          "votesAgainst": 3,
+          "episodeNum": 3,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": 5
+        },
+        {
+          "votesAgainst": 2,
+          "episodeNum": 4,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": 2
+        }
+      ],
+      "type": "Unknown",
+      "titleEn": "Golden Kamuy",
+      "seasonId": null,
+      "episodes": -1
+    }
+  },
+  {
+    "id": "seasons/1242888778/series/1242888778-14",
+    "data": {
+      "votingStatus": 0,
+      "votingRecord": [
+        {
+          "votesAgainst": -1,
+          "episodeNum": -1,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": -1
+        },
+        {
+          "votesAgainst": 5,
+          "episodeNum": 1,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": 4
+        }
+      ],
+      "type": "Unknown",
+      "titleEn": "Persona 5 the Animation",
+      "seasonId": null,
+      "episodes": -1
+    }
+  },
+  {
+    "id": "seasons/1242888778/series/1242888778-15",
     "data": {
       "votingStatus": 0,
       "votingRecord": [
@@ -589,7 +311,106 @@
     }
   },
   {
-    "id": "seasons/1242888778/series/w9MVyRm8ksgnyFdut8O0",
+    "id": "seasons/1242888778/series/1242888778-16",
+    "data": {
+      "votingStatus": 0,
+      "votingRecord": [
+        {
+          "votesAgainst": -1,
+          "episodeNum": -1,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": -1
+        },
+        {
+          "votesAgainst": 5,
+          "episodeNum": 1,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": 4
+        }
+      ],
+      "type": "Unknown",
+      "titleEn": "Sword Art Online: Gun Gale Online",
+      "seasonId": null,
+      "episodes": -1
+    }
+  },
+  {
+    "id": "seasons/1242888778/series/1242888778-17",
+    "data": {
+      "votingStatus": 0,
+      "votingRecord": [
+        {
+          "votesAgainst": -1,
+          "episodeNum": -1,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": -1
+        },
+        {
+          "votesAgainst": 6,
+          "episodeNum": 1,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": 3
+        }
+      ],
+      "type": "Unknown",
+      "titleEn": "Last Period: Owarinaki Rasen no Monogatari",
+      "seasonId": null,
+      "episodes": -1
+    }
+  },
+  {
+    "id": "seasons/1242888778/series/1242888778-18",
+    "data": {
+      "votingStatus": 0,
+      "votingRecord": [
+        {
+          "votesAgainst": -1,
+          "episodeNum": -1,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": -1
+        },
+        {
+          "votesAgainst": 3,
+          "episodeNum": 1,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": 5
+        },
+        {
+          "votesAgainst": 0,
+          "episodeNum": 2,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": 8
+        },
+        {
+          "votesAgainst": 2,
+          "episodeNum": 3,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": 6
+        },
+        {
+          "votesAgainst": 0,
+          "episodeNum": 4,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": 5
+        }
+      ],
+      "type": "Unknown",
+      "titleEn": "Hinamatsuri",
+      "seasonId": null,
+      "episodes": -1
+    }
+  },
+  {
+    "id": "seasons/1242888778/series/1242888778-2",
     "data": {
       "votingStatus": 0,
       "votingRecord": [
@@ -602,13 +423,138 @@
         }
       ],
       "type": "Unknown",
-      "titleEn": "Mahou Shoujo Ore",
+      "titleEn": "Mahou Shoujo Site",
       "seasonId": null,
       "episodes": -1
     }
   },
   {
-    "id": "seasons/1242888778/series/yPgk54vH6R4eIILFcZCj",
+    "id": "seasons/1242888778/series/1242888778-3",
+    "data": {
+      "votingStatus": 0,
+      "votingRecord": [
+        {
+          "votesAgainst": 4,
+          "episodeNum": 1,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": 3
+        }
+      ],
+      "type": "Unknown",
+      "titleEn": "Uma Musume: Pretty Derby",
+      "seasonId": null,
+      "episodes": -1
+    }
+  },
+  {
+    "id": "seasons/1242888778/series/1242888778-4",
+    "data": {
+      "votingStatus": 0,
+      "votingRecord": [
+        {
+          "votesAgainst": 2,
+          "episodeNum": 1,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": 4
+        },
+        {
+          "votesAgainst": -1,
+          "episodeNum": -1,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": -1
+        },
+        {
+          "votesAgainst": 2,
+          "episodeNum": 2,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": 7
+        },
+        {
+          "votesAgainst": 1,
+          "episodeNum": 3,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": 6
+        },
+        {
+          "votesAgainst": 1,
+          "episodeNum": 4,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": 5
+        }
+      ],
+      "type": "Unknown",
+      "titleEn": "Megalo Box",
+      "seasonId": null,
+      "episodes": -1
+    }
+  },
+  {
+    "id": "seasons/1242888778/series/1242888778-5",
+    "data": {
+      "votingStatus": 0,
+      "votingRecord": [
+        {
+          "votesAgainst": 4,
+          "episodeNum": 1,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": 4
+        },
+        {
+          "votesAgainst": -1,
+          "episodeNum": -1,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": -1
+        },
+        {
+          "votesAgainst": 7,
+          "episodeNum": 2,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": 3
+        }
+      ],
+      "type": "Unknown",
+      "titleEn": "Ginga Eiyuu Densetsu: Die Neue These - Kaikou",
+      "seasonId": null,
+      "episodes": -1
+    }
+  },
+  {
+    "id": "seasons/1242888778/series/1242888778-6",
+    "data": {
+      "votingStatus": 0,
+      "votingRecord": [
+        {
+          "votesAgainst": 3,
+          "episodeNum": 1,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": 5
+        },
+        {
+          "votesAgainst": -1,
+          "episodeNum": -1,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": -1
+        }
+      ],
+      "type": "Unknown",
+      "titleEn": "Gurazeni",
+      "seasonId": null,
+      "episodes": -1
+    }
+  },
+  {
+    "id": "seasons/1242888778/series/1242888778-7",
     "data": {
       "votingStatus": 0,
       "votingRecord": [
@@ -655,7 +601,7 @@
     }
   },
   {
-    "id": "seasons/1242888778/series/zP1LiDu7PlKdevY5ZUeK",
+    "id": "seasons/1242888778/series/1242888778-8",
     "data": {
       "votingStatus": 0,
       "votingRecord": [
@@ -667,21 +613,28 @@
           "votesFor": -1
         },
         {
-          "votesAgainst": 5,
+          "votesAgainst": 3,
           "episodeNum": 1,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": 4
+        },
+        {
+          "votesAgainst": 5,
+          "episodeNum": 2,
           "seriesId": -1,
           "weekNum": -1,
           "votesFor": 4
         }
       ],
       "type": "Unknown",
-      "titleEn": "Sword Art Online: Gun Gale Online",
+      "titleEn": "Gegege no Kitaro (2018)",
       "seasonId": null,
       "episodes": -1
     }
   },
   {
-    "id": "seasons/281991772/series/1V9qOYqHP3cVhGXhNLIp",
+    "id": "seasons/1242888778/series/1242888778-9",
     "data": {
       "votingStatus": 0,
       "votingRecord": [
@@ -695,186 +648,26 @@
         {
           "votesAgainst": 1,
           "episodeNum": 1,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": 5
-        },
-        {
-          "votesAgainst": 2,
-          "episodeNum": 2,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": 3
-        },
-        {
-          "votesAgainst": 3,
-          "episodeNum": 3,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": 5
-        },
-        {
-          "votesAgainst": 2,
-          "episodeNum": 4,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": 3
-        }
-      ],
-      "type": "Unknown",
-      "titleEn": "Yurucamp",
-      "seasonId": null,
-      "episodes": -1
-    }
-  },
-  {
-    "id": "seasons/281991772/series/3ObndhT8BK6NmmtumlXu",
-    "data": {
-      "votingStatus": 0,
-      "votingRecord": [
-        {
-          "votesAgainst": -1,
-          "episodeNum": -1,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": -1
-        },
-        {
-          "votesAgainst": -1,
-          "episodeNum": -1,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": -1
-        },
-        {
-          "votesAgainst": 1,
-          "episodeNum": 2,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": 5
-        },
-        {
-          "votesAgainst": 2,
-          "episodeNum": 3,
           "seriesId": -1,
           "weekNum": -1,
           "votesFor": 6
         },
         {
-          "votesAgainst": 2,
-          "episodeNum": 4,
+          "votesAgainst": 3,
+          "episodeNum": 2,
           "seriesId": -1,
           "weekNum": -1,
-          "votesFor": 4
-        }
-      ],
-      "type": "Unknown",
-      "titleEn": "Violet Evergarden",
-      "seasonId": null,
-      "episodes": -1
-    }
-  },
-  {
-    "id": "seasons/281991772/series/5XIoHAbonO1uD0HNfaMq",
-    "data": {
-      "votingStatus": 0,
-      "votingRecord": [
-        {
-          "votesAgainst": -1,
-          "episodeNum": -1,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": -1
-        },
-        {
-          "votesAgainst": 2,
-          "episodeNum": 1,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": 5
+          "votesFor": 7
         },
         {
           "votesAgainst": 4,
-          "episodeNum": 2,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": 2
-        }
-      ],
-      "type": "Unknown",
-      "titleEn": "Darling in the Franxx",
-      "seasonId": null,
-      "episodes": -1
-    }
-  },
-  {
-    "id": "seasons/281991772/series/EpNaUT6tABGnIQ259CeP",
-    "data": {
-      "votingStatus": 0,
-      "votingRecord": [
-        {
-          "votesAgainst": 3,
-          "episodeNum": 1,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": 4
-        },
-        {
-          "votesAgainst": -1,
-          "episodeNum": -1,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": -1
-        },
-        {
-          "votesAgainst": 5,
-          "episodeNum": 2,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": 2
-        }
-      ],
-      "type": "Unknown",
-      "titleEn": "Ryuuou no Oshigoto",
-      "seasonId": null,
-      "episodes": -1
-    }
-  },
-  {
-    "id": "seasons/281991772/series/FQwmzCXdVriDw8bGFKLE",
-    "data": {
-      "votingStatus": 0,
-      "votingRecord": [
-        {
-          "votesAgainst": 3,
-          "episodeNum": 1,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": 4
-        },
-        {
-          "votesAgainst": -1,
-          "episodeNum": -1,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": -1
-        },
-        {
-          "votesAgainst": 1,
-          "episodeNum": 2,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": 5
-        },
-        {
-          "votesAgainst": 2,
           "episodeNum": 3,
           "seriesId": -1,
           "weekNum": -1,
-          "votesFor": 5
+          "votesFor": 4
         },
         {
-          "votesAgainst": 1,
+          "votesAgainst": 2,
           "episodeNum": 4,
           "seriesId": -1,
           "weekNum": -1,
@@ -882,46 +675,13 @@
         }
       ],
       "type": "Unknown",
-      "titleEn": "Sora yori mo Tooi Basho",
+      "titleEn": "Wotakoi",
       "seasonId": null,
       "episodes": -1
     }
   },
   {
-    "id": "seasons/281991772/series/GlMxuXVLTgIpJUO9JQYD",
-    "data": {
-      "votingStatus": 0,
-      "votingRecord": [
-        {
-          "votesAgainst": -1,
-          "episodeNum": -1,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": -1
-        },
-        {
-          "votesAgainst": -1,
-          "episodeNum": -1,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": -1
-        },
-        {
-          "votesAgainst": 5,
-          "episodeNum": 14,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": 0
-        }
-      ],
-      "type": "Unknown",
-      "titleEn": "Mahoutsukai no Yome",
-      "seasonId": null,
-      "episodes": -1
-    }
-  },
-  {
-    "id": "seasons/281991772/series/JjsC5sIzBmQnxRyvZn0j",
+    "id": "seasons/281991772/series/281991772-0",
     "data": {
       "votingStatus": 0,
       "votingRecord": [
@@ -954,17 +714,10 @@
     }
   },
   {
-    "id": "seasons/281991772/series/Lg0ZktD6dnuOYZSUpqTu",
+    "id": "seasons/281991772/series/281991772-1",
     "data": {
       "votingStatus": 0,
       "votingRecord": [
-        {
-          "votesAgainst": -1,
-          "episodeNum": -1,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": -1
-        },
         {
           "votesAgainst": 4,
           "episodeNum": 1,
@@ -974,13 +727,13 @@
         }
       ],
       "type": "Unknown",
-      "titleEn": "Citrus",
+      "titleEn": "Karakai Jouzu no Takagi-san",
       "seasonId": null,
       "episodes": -1
     }
   },
   {
-    "id": "seasons/281991772/series/NleFTXzdfO14OS972Pgy",
+    "id": "seasons/281991772/series/281991772-10",
     "data": {
       "votingStatus": 0,
       "votingRecord": [
@@ -1013,26 +766,99 @@
     }
   },
   {
-    "id": "seasons/281991772/series/QxOkpWRgVrtoAGRvUkgL",
+    "id": "seasons/281991772/series/281991772-11",
     "data": {
       "votingStatus": 0,
       "votingRecord": [
         {
-          "votesAgainst": 4,
+          "votesAgainst": -1,
+          "episodeNum": -1,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": -1
+        },
+        {
+          "votesAgainst": 2,
           "episodeNum": 1,
           "seriesId": -1,
           "weekNum": -1,
-          "votesFor": 3
+          "votesFor": 5
+        },
+        {
+          "votesAgainst": 4,
+          "episodeNum": 2,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": 2
         }
       ],
       "type": "Unknown",
-      "titleEn": "Märchen Mädchen",
+      "titleEn": "Darling in the Franxx",
       "seasonId": null,
       "episodes": -1
     }
   },
   {
-    "id": "seasons/281991772/series/cChZfvA6DU0NgDf1C46R",
+    "id": "seasons/281991772/series/281991772-12",
+    "data": {
+      "votingStatus": 0,
+      "votingRecord": [
+        {
+          "votesAgainst": -1,
+          "episodeNum": -1,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": -1
+        },
+        {
+          "votesAgainst": 3,
+          "episodeNum": 1,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": 3
+        },
+        {
+          "votesAgainst": 4,
+          "episodeNum": 2,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": 1
+        }
+      ],
+      "type": "Unknown",
+      "titleEn": "Hakumei to Mikochi",
+      "seasonId": null,
+      "episodes": -1
+    }
+  },
+  {
+    "id": "seasons/281991772/series/281991772-13",
+    "data": {
+      "votingStatus": 0,
+      "votingRecord": [
+        {
+          "votesAgainst": -1,
+          "episodeNum": -1,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": -1
+        },
+        {
+          "votesAgainst": 6,
+          "episodeNum": 1,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": 1
+        }
+      ],
+      "type": "Unknown",
+      "titleEn": "Toji no Miko",
+      "seasonId": null,
+      "episodes": -1
+    }
+  },
+  {
+    "id": "seasons/281991772/series/281991772-14",
     "data": {
       "votingStatus": 0,
       "votingRecord": [
@@ -1079,26 +905,33 @@
     }
   },
   {
-    "id": "seasons/281991772/series/fKrWskwEgfsaLqHQausG",
+    "id": "seasons/281991772/series/281991772-15",
     "data": {
       "votingStatus": 0,
       "votingRecord": [
         {
-          "votesAgainst": 7,
+          "votesAgainst": -1,
+          "episodeNum": -1,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": -1
+        },
+        {
+          "votesAgainst": 4,
           "episodeNum": 1,
           "seriesId": -1,
           "weekNum": -1,
-          "votesFor": 0
+          "votesFor": 3
         }
       ],
       "type": "Unknown",
-      "titleEn": "Gakuen Babysitters",
+      "titleEn": "Citrus",
       "seasonId": null,
       "episodes": -1
     }
   },
   {
-    "id": "seasons/281991772/series/gZmraSJLmKo07ni4gW1w",
+    "id": "seasons/281991772/series/281991772-16",
     "data": {
       "votingStatus": 0,
       "votingRecord": [
@@ -1131,177 +964,7 @@
     }
   },
   {
-    "id": "seasons/281991772/series/iuFYV1f8wpE6dtZk8cJ8",
-    "data": {
-      "votingStatus": 0,
-      "votingRecord": [
-        {
-          "votesAgainst": -1,
-          "episodeNum": -1,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": -1
-        },
-        {
-          "votesAgainst": 3,
-          "episodeNum": 1,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": 3
-        },
-        {
-          "votesAgainst": 4,
-          "episodeNum": 2,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": 1
-        }
-      ],
-      "type": "Unknown",
-      "titleEn": "Hakumei to Mikochi",
-      "seasonId": null,
-      "episodes": -1
-    }
-  },
-  {
-    "id": "seasons/281991772/series/j8kHmmXAExC0qN3BufvU",
-    "data": {
-      "votingStatus": 0,
-      "votingRecord": [
-        {
-          "votesAgainst": 3,
-          "episodeNum": 1,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": 4
-        },
-        {
-          "votesAgainst": -1,
-          "episodeNum": -1,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": -1
-        },
-        {
-          "votesAgainst": 2,
-          "episodeNum": 2,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": 6
-        },
-        {
-          "votesAgainst": 2,
-          "episodeNum": 3,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": 4
-        },
-        {
-          "votesAgainst": 2,
-          "episodeNum": 4,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": 4
-        }
-      ],
-      "type": "Unknown",
-      "titleEn": "Devilman Crybaby",
-      "seasonId": null,
-      "episodes": -1
-    }
-  },
-  {
-    "id": "seasons/281991772/series/jEVJZjH6Db4ID26BtHmU",
-    "data": {
-      "votingStatus": 0,
-      "votingRecord": [
-        {
-          "votesAgainst": -1,
-          "episodeNum": -1,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": -1
-        },
-        {
-          "votesAgainst": 6,
-          "episodeNum": 1,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": 1
-        }
-      ],
-      "type": "Unknown",
-      "titleEn": "Toji no Miko",
-      "seasonId": null,
-      "episodes": -1
-    }
-  },
-  {
-    "id": "seasons/281991772/series/mrLhyjjIOV8Cz0YbbU7a",
-    "data": {
-      "votingStatus": 0,
-      "votingRecord": [
-        {
-          "votesAgainst": 4,
-          "episodeNum": 1,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": 3
-        }
-      ],
-      "type": "Unknown",
-      "titleEn": "Karakai Jouzu no Takagi-san",
-      "seasonId": null,
-      "episodes": -1
-    }
-  },
-  {
-    "id": "seasons/281991772/series/nosfgYzSUGBhDuXzKdXo",
-    "data": {
-      "votingStatus": 0,
-      "votingRecord": [
-        {
-          "votesAgainst": 5,
-          "episodeNum": 1,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": 2
-        }
-      ],
-      "type": "Unknown",
-      "titleEn": "Hakata Tonkotsu Ramens",
-      "seasonId": null,
-      "episodes": -1
-    }
-  },
-  {
-    "id": "seasons/281991772/series/pfSDliltkR9E8bYx7sSR",
-    "data": {
-      "votingStatus": 0,
-      "votingRecord": [
-        {
-          "votesAgainst": -1,
-          "episodeNum": -1,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": -1
-        },
-        {
-          "votesAgainst": 4,
-          "episodeNum": 1,
-          "seriesId": -1,
-          "weekNum": -1,
-          "votesFor": 0
-        }
-      ],
-      "type": "Unknown",
-      "titleEn": "Sanrio Danshi",
-      "seasonId": null,
-      "episodes": -1
-    }
-  },
-  {
-    "id": "seasons/281991772/series/sf33g4cvvo3yyxWhA1L5",
+    "id": "seasons/281991772/series/281991772-17",
     "data": {
       "votingStatus": 0,
       "votingRecord": [
@@ -1327,7 +990,7 @@
     }
   },
   {
-    "id": "seasons/281991772/series/uABDJWqC8goTWeHxI1Ci",
+    "id": "seasons/281991772/series/281991772-18",
     "data": {
       "votingStatus": 0,
       "votingRecord": [
@@ -1374,7 +1037,132 @@
     }
   },
   {
-    "id": "seasons/281991772/series/zkpqzd65tTryfLYHA2j7",
+    "id": "seasons/281991772/series/281991772-19",
+    "data": {
+      "votingStatus": 0,
+      "votingRecord": [
+        {
+          "votesAgainst": -1,
+          "episodeNum": -1,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": -1
+        },
+        {
+          "votesAgainst": 4,
+          "episodeNum": 1,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": 0
+        }
+      ],
+      "type": "Unknown",
+      "titleEn": "Sanrio Danshi",
+      "seasonId": null,
+      "episodes": -1
+    }
+  },
+  {
+    "id": "seasons/281991772/series/281991772-2",
+    "data": {
+      "votingStatus": 0,
+      "votingRecord": [
+        {
+          "votesAgainst": 5,
+          "episodeNum": 1,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": 2
+        }
+      ],
+      "type": "Unknown",
+      "titleEn": "Hakata Tonkotsu Ramens",
+      "seasonId": null,
+      "episodes": -1
+    }
+  },
+  {
+    "id": "seasons/281991772/series/281991772-20",
+    "data": {
+      "votingStatus": 0,
+      "votingRecord": [
+        {
+          "votesAgainst": -1,
+          "episodeNum": -1,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": -1
+        },
+        {
+          "votesAgainst": 1,
+          "episodeNum": 1,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": 5
+        },
+        {
+          "votesAgainst": 2,
+          "episodeNum": 2,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": 3
+        },
+        {
+          "votesAgainst": 3,
+          "episodeNum": 3,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": 5
+        },
+        {
+          "votesAgainst": 2,
+          "episodeNum": 4,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": 3
+        }
+      ],
+      "type": "Unknown",
+      "titleEn": "Yurucamp",
+      "seasonId": null,
+      "episodes": -1
+    }
+  },
+  {
+    "id": "seasons/281991772/series/281991772-21",
+    "data": {
+      "votingStatus": 0,
+      "votingRecord": [
+        {
+          "votesAgainst": -1,
+          "episodeNum": -1,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": -1
+        },
+        {
+          "votesAgainst": -1,
+          "episodeNum": -1,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": -1
+        },
+        {
+          "votesAgainst": 5,
+          "episodeNum": 14,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": 0
+        }
+      ],
+      "type": "Unknown",
+      "titleEn": "Mahoutsukai no Yome",
+      "seasonId": null,
+      "episodes": -1
+    }
+  },
+  {
+    "id": "seasons/281991772/series/281991772-3",
     "data": {
       "votingStatus": 0,
       "votingRecord": [
@@ -1416,6 +1204,218 @@
       ],
       "type": "Unknown",
       "titleEn": "Koi wa Ameagari no You ni",
+      "seasonId": null,
+      "episodes": -1
+    }
+  },
+  {
+    "id": "seasons/281991772/series/281991772-4",
+    "data": {
+      "votingStatus": 0,
+      "votingRecord": [
+        {
+          "votesAgainst": 3,
+          "episodeNum": 1,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": 4
+        },
+        {
+          "votesAgainst": -1,
+          "episodeNum": -1,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": -1
+        },
+        {
+          "votesAgainst": 5,
+          "episodeNum": 2,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": 2
+        }
+      ],
+      "type": "Unknown",
+      "titleEn": "Ryuuou no Oshigoto",
+      "seasonId": null,
+      "episodes": -1
+    }
+  },
+  {
+    "id": "seasons/281991772/series/281991772-5",
+    "data": {
+      "votingStatus": 0,
+      "votingRecord": [
+        {
+          "votesAgainst": 7,
+          "episodeNum": 1,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": 0
+        }
+      ],
+      "type": "Unknown",
+      "titleEn": "Gakuen Babysitters",
+      "seasonId": null,
+      "episodes": -1
+    }
+  },
+  {
+    "id": "seasons/281991772/series/281991772-6",
+    "data": {
+      "votingStatus": 0,
+      "votingRecord": [
+        {
+          "votesAgainst": 3,
+          "episodeNum": 1,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": 4
+        },
+        {
+          "votesAgainst": -1,
+          "episodeNum": -1,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": -1
+        },
+        {
+          "votesAgainst": 1,
+          "episodeNum": 2,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": 5
+        },
+        {
+          "votesAgainst": 2,
+          "episodeNum": 3,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": 5
+        },
+        {
+          "votesAgainst": 1,
+          "episodeNum": 4,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": 4
+        }
+      ],
+      "type": "Unknown",
+      "titleEn": "Sora yori mo Tooi Basho",
+      "seasonId": null,
+      "episodes": -1
+    }
+  },
+  {
+    "id": "seasons/281991772/series/281991772-7",
+    "data": {
+      "votingStatus": 0,
+      "votingRecord": [
+        {
+          "votesAgainst": -1,
+          "episodeNum": -1,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": -1
+        },
+        {
+          "votesAgainst": -1,
+          "episodeNum": -1,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": -1
+        },
+        {
+          "votesAgainst": 1,
+          "episodeNum": 2,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": 5
+        },
+        {
+          "votesAgainst": 2,
+          "episodeNum": 3,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": 6
+        },
+        {
+          "votesAgainst": 2,
+          "episodeNum": 4,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": 4
+        }
+      ],
+      "type": "Unknown",
+      "titleEn": "Violet Evergarden",
+      "seasonId": null,
+      "episodes": -1
+    }
+  },
+  {
+    "id": "seasons/281991772/series/281991772-8",
+    "data": {
+      "votingStatus": 0,
+      "votingRecord": [
+        {
+          "votesAgainst": 4,
+          "episodeNum": 1,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": 3
+        }
+      ],
+      "type": "Unknown",
+      "titleEn": "Märchen Mädchen",
+      "seasonId": null,
+      "episodes": -1
+    }
+  },
+  {
+    "id": "seasons/281991772/series/281991772-9",
+    "data": {
+      "votingStatus": 0,
+      "votingRecord": [
+        {
+          "votesAgainst": 3,
+          "episodeNum": 1,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": 4
+        },
+        {
+          "votesAgainst": -1,
+          "episodeNum": -1,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": -1
+        },
+        {
+          "votesAgainst": 2,
+          "episodeNum": 2,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": 6
+        },
+        {
+          "votesAgainst": 2,
+          "episodeNum": 3,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": 4
+        },
+        {
+          "votesAgainst": 2,
+          "episodeNum": 4,
+          "seriesId": -1,
+          "weekNum": -1,
+          "votesFor": 4
+        }
+      ],
+      "type": "Unknown",
+      "titleEn": "Devilman Crybaby",
       "seasonId": null,
       "episodes": -1
     }

--- a/model/firestore.ts
+++ b/model/firestore.ts
@@ -39,10 +39,11 @@ export interface SeasonModel {
 // group
 export const SERIES_COLLECTION = 'series';
 
+// Pulled from AniList.co schema
 export enum SeriesType {
   Unknown = 'Unknown',
-  Series = 'Series',
-  Short = 'Short',
+  Series = 'TV',
+  Short = 'TV_SHORT',
 }
 
 export interface SeriesModel {

--- a/model/service.ts
+++ b/model/service.ts
@@ -38,3 +38,14 @@ export interface SyncFromVotingSheetResponse {
   data?: {};  // sheets_v4.Schema$Spreadsheet
   err?: string;
 }
+
+// Set the AniList Id of a series in the voting sheet
+export interface SetSeriesIdRequest {
+  seasonId?: number;
+  row?: number;
+  seriesId?: number
+}
+export interface SetSeriesIdResponse {
+  data?: {};  // wip
+  err?: string;
+}

--- a/model/sheets.ts
+++ b/model/sheets.ts
@@ -26,6 +26,15 @@ export interface WorksheetModel {
  * Metadata key for the Anilist.co Id for the series associated with this row.
  */
 export const SERIES_AL_ID_KEY = 'series-anilist-id';
+/** Payload to stringify as the value for the seriesID metadata */
+export interface SeriesMetadataPayload {
+  alId: number;
+  malId: number;
+  type: string;
+  episodes: number;
+  titleEn: string;
+}
+
 /**
  * Metadata key for the type ('SERIES', 'SHORT') of the series associated with
  * this row.


### PR DESCRIPTION
Added a 'setSeriesId' cloud function which calls out to AniList.co for metadata about the series, and stores that metadata in DevMetadata in Googlesheets and Firestore.

Added some mocking infra and tests for this endpoint.

Still some work to do. Specifically it should store more than just the AniList Id in sheets. Maybe stringify the whole payload? or use multiple metadata.

Need test coverage for errors.