### PR TITLE
Display the Voting results in a grid in the UI

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1181,6 +1181,30 @@
         "react-transition-group": "^4.3.0"
       }
     },
+    "@material-ui/lab": {
+      "version": "4.0.0-alpha.36",
+      "resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.0.0-alpha.36.tgz",
+      "integrity": "sha512-T5dMW4RYmjH/VWjXui5uBPcqfMsKv5Ig/uX77UwTQts2CS6YeNF7619WtEm6yl9kV2O5CVpRsPw1ulrt2T2Hrg==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/utils": "^4.7.1",
+        "clsx": "^1.0.4",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.0"
+      },
+      "dependencies": {
+        "@material-ui/utils": {
+          "version": "4.7.1",
+          "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.7.1.tgz",
+          "integrity": "sha512-+ux0SlLdlehvzCk2zdQ3KiS3/ylWvuo/JwAGhvb8dFVvwR21K28z0PU9OQW2PGogrMEdvX3miEI5tGxTwwWiwQ==",
+          "requires": {
+            "@babel/runtime": "^7.4.4",
+            "prop-types": "^15.7.2",
+            "react-is": "^16.8.0"
+          }
+        }
+      }
+    },
     "@material-ui/pickers": {
       "version": "3.2.8",
       "resolved": "https://registry.npmjs.org/@material-ui/pickers/-/pickers-3.2.8.tgz",

--- a/app/package.json
+++ b/app/package.json
@@ -7,6 +7,7 @@
     "@date-io/core": "^1.3.11",
     "@date-io/date-fns": "^1.3.11",
     "@material-ui/core": "^4.7.0",
+    "@material-ui/lab": "^4.0.0-alpha.36",
     "@material-ui/pickers": "^3.2.8",
     "@types/jest": "^24.0.23",
     "@types/node": "^12.12.11",

--- a/app/src/app/SeasonDetail.tsx
+++ b/app/src/app/SeasonDetail.tsx
@@ -144,14 +144,6 @@ const SeasonDetail: React.FC<SeasonDetailProps> = ({ dispatch, backendURI, seaso
     setSelectedSeries(null);
   }
 
-  const DialogButton = ({ onClick, series }: { onClick: Function, series: SeriesModel }) => {
-    const handleClick = () => {
-      onClick(series);
-    };
-
-    return (<Button onClick={handleClick}>Edit</Button>);
-  }
-
   return (
     <div>
       <Paper className={classes.header}>
@@ -177,39 +169,104 @@ const SeasonDetail: React.FC<SeasonDetailProps> = ({ dispatch, backendURI, seaso
           <Icon className="push-left warning-icon text-top">warning</Icon>
         </Tooltip>}
       </Paper>
-      <Paper className={classes.root}>
-        <Table className={classes.table} aria-label="simple table">
-          <TableHead>
-            <TableRow>
-              <TableCell>Series Name&nbsp;(Raw)</TableCell>
-              <TableCell>Series Name&nbsp;(AniList)</TableCell>
-              <TableCell align="right">AniList&nbsp;ID</TableCell>
-              <TableCell align="right">MAL&nbsp;ID</TableCell>
-              <TableCell align="right">Type</TableCell>
-              <TableCell align="right">Episodes</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {seriesList.map((series) => (
-              <TableRow key={series.rowIndex}>
-                <TableCell component="th" scope="row">
-                  {series.titleRaw}
-                </TableCell>
-                <TableCell>{series.titleEn}</TableCell>
-                <TableCell align="right">{series.idAL}</TableCell>
-                <TableCell align="right">{series.idMal}</TableCell>
-                <TableCell align="right">{series.type}</TableCell>
-                <TableCell align="right">{series.episodes}</TableCell>
-                <TableCell>
-                  <DialogButton onClick={openSeriesIdDialog} series={series} />
-                </TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </Paper>
+      <SeriesVotingGrid seriesList={seriesList}></SeriesVotingGrid>
+      {/* <SeriesDebugGrid seriesList={seriesList} openIDDialog={openSeriesIdDialog}></SeriesDebugGrid> */}
       <SetSeriesIdDialog open={idDialogOpen} onClose={handleSeriesIdDialogConfirm} series={selectedSeries}></SetSeriesIdDialog>
     </div>
+  );
+}
+
+function SeriesVotingGrid({ seriesList }: { seriesList: SeriesModel[] }) {
+  const classes = useStyles();
+
+  const maxWeeks = seriesList.reduce((max, series) => {
+    const weekNum = series.votingRecord[series.votingRecord.length - 1].weekNum;
+    if (weekNum > max) {
+      return weekNum;
+    } else {
+      return max;
+    }
+  }, 0);
+
+  const headers = [];
+  for (let i = 1; i <= maxWeeks; i++) {
+    headers.push(<TableCell align="right">Week {i}</TableCell>)
+  }
+
+  return (
+    <Paper className={classes.root}>
+      <Table className={classes.table} aria-label="series voting grid">
+        <TableHead>
+          <TableRow>
+            <TableCell>Series Name</TableCell>
+            <TableCell>Status</TableCell>
+            {headers}
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {seriesList.map((series) => (
+            <TableRow key={series.rowIndex}>
+              <TableCell component="th" scope="row">
+                {series.titleRaw}
+              </TableCell>
+              <TableCell>{series.votingStatus}</TableCell>
+              {series.votingRecord.map((record) => (
+                <TableCell align="right">{[
+                  'Ep', record.episodeNum, ':',
+                  record.votesFor, '-', record.votesAgainst]
+                  .join(' ')}</TableCell>
+              ))}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </Paper>
+  );
+}
+
+function SeriesDebugGrid({ seriesList, openIDDialog }: { seriesList: SeriesModel[], openIDDialog: (series: SeriesModel) => void }) {
+  const classes = useStyles();
+
+  const DialogButton = ({ onClick, series }: { onClick: Function, series: SeriesModel }) => {
+    const handleClick = () => {
+      onClick(series);
+    };
+
+    return (<Button onClick={handleClick}>Edit</Button>);
+  }
+
+  return (
+    <Paper className={classes.root}>
+      <Table className={classes.table} aria-label="series debug grid">
+        <TableHead>
+          <TableRow>
+            <TableCell>Series Name&nbsp;(Raw)</TableCell>
+            <TableCell>Series Name&nbsp;(AniList)</TableCell>
+            <TableCell align="right">AniList&nbsp;ID</TableCell>
+            <TableCell align="right">MAL&nbsp;ID</TableCell>
+            <TableCell align="right">Type</TableCell>
+            <TableCell align="right">Episodes</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {seriesList.map((series) => (
+            <TableRow key={series.rowIndex}>
+              <TableCell component="th" scope="row">
+                {series.titleRaw}
+              </TableCell>
+              <TableCell>{series.titleEn}</TableCell>
+              <TableCell align="right">{series.idAL}</TableCell>
+              <TableCell align="right">{series.idMal}</TableCell>
+              <TableCell align="right">{series.type}</TableCell>
+              <TableCell align="right">{series.episodes}</TableCell>
+              <TableCell>
+                <DialogButton onClick={openIDDialog} series={series} />
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </Paper>
   );
 }
 

--- a/app/src/app/SeasonDetail.tsx
+++ b/app/src/app/SeasonDetail.tsx
@@ -6,6 +6,7 @@ import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import { MuiPickersUtilsProvider, KeyboardDatePicker } from '@material-ui/pickers';
 import DateFnsUtils from '@date-io/date-fns';
 import { Tooltip, Icon, Paper, Table, TableHead, TableRow, TableCell, TableBody, Dialog, DialogTitle, Button, DialogActions, DialogContent, TextField } from '@material-ui/core';
+import ToggleButton from '@material-ui/lab/ToggleButton';
 import { SeasonModel, SeriesModel } from '../../../model/firestore';
 import { AppActions } from '../state/actions';
 import { GetAllSeriesResponse } from '../../../model/service';
@@ -107,6 +108,7 @@ const SeasonDetail: React.FC<SeasonDetailProps> = ({ dispatch, backendURI, seaso
   const { seasonId } = useParams();
   const [idDialogOpen, setDialogOpen] = useState(false);
   const [selectedSeries, setSelectedSeries] = useState<SeriesModel | null>(null);
+  const [showDebug, setShowDebug] = useState<boolean>(false);
   const classes = useStyles();
 
   // Load all season data on start using effect Hook
@@ -168,9 +170,19 @@ const SeasonDetail: React.FC<SeasonDetailProps> = ({ dispatch, backendURI, seaso
         {season.startDate === null && <Tooltip title="Missing Start Date">
           <Icon className="push-left warning-icon text-top">warning</Icon>
         </Tooltip>}
+        <ToggleButton
+          value="debug"
+          selected={showDebug}
+          onChange={() => {
+            setShowDebug(!showDebug);
+          }}>
+          {/* <BugReportIcon /> */}
+          Debug
+        </ToggleButton>
       </Paper>
-      <SeriesVotingGrid seriesList={seriesList}></SeriesVotingGrid>
-      {/* <SeriesDebugGrid seriesList={seriesList} openIDDialog={openSeriesIdDialog}></SeriesDebugGrid> */}
+      {showDebug && <SeriesDebugGrid seriesList={seriesList} openIDDialog={openSeriesIdDialog}></SeriesDebugGrid>}
+      {!showDebug && <SeriesVotingGrid seriesList={seriesList}></SeriesVotingGrid>}
+
       <SetSeriesIdDialog open={idDialogOpen} onClose={handleSeriesIdDialogConfirm} series={selectedSeries}></SetSeriesIdDialog>
     </div>
   );


### PR DESCRIPTION
Adds a toggle to display either the Voting records in a grid, or the series metadata (AniList ID, etc).

Includes @material-ui/lab for the toggle button. Which is experimental and has some vulnerabilities. Might not be needed for just a simple button.