### PR TITLE
Producing valid voting records for 'BYE' cells and 'PASS' cells

### DIFF
--- a/app/src/app/SeasonDetail.tsx
+++ b/app/src/app/SeasonDetail.tsx
@@ -202,7 +202,7 @@ function SeriesVotingGrid({ seriesList }: { seriesList: SeriesModel[] }) {
 
   const headers = [];
   for (let i = 1; i <= maxWeeks; i++) {
-    headers.push(<TableCell align="right">Week {i}</TableCell>)
+    headers.push(<TableCell key={i} align="right">Week {i}</TableCell>)
   }
 
   return (
@@ -223,10 +223,11 @@ function SeriesVotingGrid({ seriesList }: { seriesList: SeriesModel[] }) {
               </TableCell>
               <TableCell>{series.votingStatus}</TableCell>
               {series.votingRecord.map((record) => (
-                <TableCell align="right">{[
-                  'Ep', record.episodeNum, ':',
-                  record.votesFor, '-', record.votesAgainst]
-                  .join(' ')}</TableCell>
+                <TableCell align="right">{
+                  record.msg ? record.msg : [
+                    'Ep', record.episodeNum, ':',
+                    record.votesFor, '-', record.votesAgainst]
+                    .join(' ')}</TableCell>
               ))}
             </TableRow>
           ))}

--- a/functions/src/helpers/aggregateVotingRecordsHelpers.test.ts
+++ b/functions/src/helpers/aggregateVotingRecordsHelpers.test.ts
@@ -173,9 +173,9 @@ describe('aggregateVotingStatus', () => {
       expect(passingSeries.votingRecord.length).toEqual(4);
       expect(passingSeries.votingRecord).toEqual([
         {...passingRecord, weekNum: 1},
-        {weekNum: 2, episodeNum: 2, votesFor: 0, votesAgainst: 0},
-        {weekNum: 3, episodeNum: 3, votesFor: 0, votesAgainst: 0},
-        {weekNum: 4, episodeNum: 4, votesFor: 0, votesAgainst: 0},
+        {msg: 'PASS', weekNum: 2, episodeNum: 2, votesFor: 0, votesAgainst: 0},
+        {msg: 'PASS', weekNum: 3, episodeNum: 3, votesFor: 0, votesAgainst: 0},
+        {msg: 'PASS', weekNum: 4, episodeNum: 4, votesFor: 0, votesAgainst: 0},
       ]);
     });
 
@@ -195,8 +195,8 @@ describe('aggregateVotingStatus', () => {
       expect(passingSeries.votingRecord.length).toEqual(3);
       expect(passingSeries.votingRecord).toEqual([
         {...passingRecord, weekNum: 1},
-        {weekNum: 2, episodeNum: 2, votesFor: 0, votesAgainst: 0},
-        {weekNum: 3, episodeNum: 3, votesFor: 0, votesAgainst: 0},
+        {msg: 'PASS', weekNum: 2, episodeNum: 2, votesFor: 0, votesAgainst: 0},
+        {msg: 'PASS', weekNum: 3, episodeNum: 3, votesFor: 0, votesAgainst: 0},
       ]);
     });
   });

--- a/functions/src/helpers/aggregateVotingRecordsHelpers.ts
+++ b/functions/src/helpers/aggregateVotingRecordsHelpers.ts
@@ -108,6 +108,7 @@ function calculateCurrentVotingStatus(
   let nextEp = lastRecord.episodeNum + 1;
   for (let i = 1; i <= weeksSinceLastRecord; i++) {
     const passRecord: SeriesVotingRecord = {
+      msg: 'PASS',
       weekNum: i + lastRecord.weekNum,
       episodeNum: nextEp,
       votesFor: 0,

--- a/functions/src/helpers/firestoreDocumentHelpers.test.ts
+++ b/functions/src/helpers/firestoreDocumentHelpers.test.ts
@@ -86,7 +86,15 @@ describe('extractFirestoreDocuments', () => {
         title: 'SPRING 2018',
         gridProperties: {},
         metadata: {},
-        data: [{metadata: {}, cells: ['Teekyuu', 'BYE']}],
+        data: [{
+          metadata: {},
+          cells: [
+            'Teekyuu',
+            'BYE',
+            'Ep 1: 0 to 0',
+            'BYE',
+          ]
+        }],
       }],
     };
 
@@ -95,12 +103,20 @@ describe('extractFirestoreDocuments', () => {
 
     expect(seriesList.length).toEqual(1);
     const series = seriesList[0];
-    expect(series.votingRecord).toEqual<SeriesVotingRecord[]>([{
+    expect(series.votingRecord.length).toEqual(3);
+    expect(series.votingRecord[0]).toEqual<SeriesVotingRecord>({
       msg: 'BYE',
       episodeNum: 0,
       weekNum: 1,
       votesFor: 0,
       votesAgainst: 0,
-    }]);
+    });
+    expect(series.votingRecord[2]).toEqual<SeriesVotingRecord>({
+      msg: 'BYE',
+      episodeNum: 1,
+      weekNum: 3,
+      votesFor: 0,
+      votesAgainst: 0,
+    });
   });
 });

--- a/functions/src/helpers/firestoreDocumentHelpers.test.ts
+++ b/functions/src/helpers/firestoreDocumentHelpers.test.ts
@@ -76,4 +76,31 @@ describe('extractFirestoreDocuments', () => {
       votesAgainst: 2,
     }]);
   });
+
+  test('should produce a BYE record for \'BYE\' cells in a series row', () => {
+    const mockData: SpreadsheetModel = {
+      spreadsheetId: 'foobar',
+      title: 'MockSpreadSheet',
+      sheets: [{
+        sheetId: 12345,
+        title: 'SPRING 2018',
+        gridProperties: {},
+        metadata: {},
+        data: [{metadata: {}, cells: ['Teekyuu', 'BYE']}],
+      }],
+    };
+
+    const docs = extractFirestoreDocuments(mockData);
+    const seriesList = docs[0].seriesList;
+
+    expect(seriesList.length).toEqual(1);
+    const series = seriesList[0];
+    expect(series.votingRecord).toEqual<SeriesVotingRecord[]>([{
+      msg: 'BYE',
+      episodeNum: 0,
+      weekNum: 1,
+      votesFor: 0,
+      votesAgainst: 0,
+    }]);
+  });
 });

--- a/functions/src/helpers/firestoreDocumentHelpers.ts
+++ b/functions/src/helpers/firestoreDocumentHelpers.ts
@@ -76,11 +76,12 @@ function extractSeriesDocuments(
  * Google Sheets.
  */
 function extractSeriesVotingRecord(cells: string[]): SeriesVotingRecord[] {
+  let prevEpisode = 0;
   return cells.map((cell, index): SeriesVotingRecord => {
     if (cell === 'BYE') {
       return {
         msg: 'BYE',
-        episodeNum: 0,
+        episodeNum: prevEpisode,
         weekNum: index + 1,
         votesAgainst: 0,
         votesFor: 0,
@@ -88,6 +89,10 @@ function extractSeriesVotingRecord(cells: string[]): SeriesVotingRecord[] {
     }
 
     const parsedCell = parseVoteCell(cell);
+    // Store the previous episode number for use in a future BYE cell
+    if (parsedCell.episode) {
+      prevEpisode = parsedCell.episode;
+    }
     return {
       episodeNum: parsedCell.episode,
       weekNum: index + 1,

--- a/functions/src/helpers/firestoreDocumentHelpers.ts
+++ b/functions/src/helpers/firestoreDocumentHelpers.ts
@@ -77,6 +77,16 @@ function extractSeriesDocuments(
  */
 function extractSeriesVotingRecord(cells: string[]): SeriesVotingRecord[] {
   return cells.map((cell, index): SeriesVotingRecord => {
+    if (cell === 'BYE') {
+      return {
+        msg: 'BYE',
+        episodeNum: 0,
+        weekNum: index + 1,
+        votesAgainst: 0,
+        votesFor: 0,
+      };
+    }
+
     const parsedCell = parseVoteCell(cell);
     return {
       episodeNum: parsedCell.episode,

--- a/model/firestore.ts
+++ b/model/firestore.ts
@@ -75,6 +75,7 @@ export const enum VotingStatus {
 }
 
 export interface SeriesVotingRecord {
+  msg?: string;
   episodeNum: number;
   weekNum: number;
   votesFor: number;


### PR DESCRIPTION
#53 

Interprets a 'BYE' string in a spreadsheet cell as a zero-vote passing record with a tag for 'BYE'. These can be displayed in the UI as a BYE cell. This is a common convention if this series couldn't be viewed that week.

Also tags the synthetic PASS voting records for the current season.