### PR TITLE
Generating a new model for OnDeckReport when syncing and store in Firestore

### DIFF
--- a/functions/src/syncFromVotingSheet.f.ts
+++ b/functions/src/syncFromVotingSheet.f.ts
@@ -6,7 +6,7 @@ import {getSheetsClient} from './google.auth';
 import {aggregateVotingStatus} from './helpers/aggregateVotingRecordsHelpers';
 import {extractFirestoreDocuments} from './helpers/firestoreDocumentHelpers';
 import {extractSheetModelFromSpreadsheetData} from './helpers/spreadsheetModelHelpers';
-import {CONFIG_COLLECTION, genSeriesId, SEASONS_COLLECTION, SERIES_COLLECTION, SYNC_STATE_KEY} from './model/firestore';
+import {CONFIG_COLLECTION, genSeriesId, ONDECK_REPORTS_COLLECTION, OnDeckReport, SEASONS_COLLECTION, SERIES_COLLECTION, SYNC_STATE_KEY} from './model/firestore';
 import {SyncFromVotingSheetResponse} from './model/service';
 
 const firestore = admin.firestore();
@@ -36,8 +36,13 @@ export const syncFromVotingSheet = functions.https.onRequest(async (_, res) => {
 
     const sheetModel = extractSheetModelFromSpreadsheetData(resp.data);
     const allDocuments = extractFirestoreDocuments(sheetModel);
+    let onDeckReport: OnDeckReport|undefined;
     allDocuments.forEach((docsTuples) => {
-      aggregateVotingStatus(docsTuples.season, docsTuples.seriesList);
+      const report =
+          aggregateVotingStatus(docsTuples.season, docsTuples.seriesList);
+      if (report) {
+        onDeckReport = report;
+      }
     });
 
     const batch = firestore.batch();
@@ -62,6 +67,13 @@ export const syncFromVotingSheet = functions.https.onRequest(async (_, res) => {
     batch.set(
         firestore.doc(CONFIG_COLLECTION + '/' + SYNC_STATE_KEY),
         {lastSync: syncTimestamp});
+
+    // Record the generated OnDeckReport
+    if (onDeckReport) {
+      onDeckReport.lastSync = syncTimestamp;
+      const docRef = firestore.collection(ONDECK_REPORTS_COLLECTION).doc();
+      batch.set(docRef, onDeckReport);
+    }
 
     await batch.commit();
 

--- a/model/firestore.ts
+++ b/model/firestore.ts
@@ -24,6 +24,7 @@ export enum Season {
   WINTER,
 }
 
+/** Model of a Season represented by a sheet in the voting sheet */
 export interface SeasonModel {
   formattedName: string;  // ex. 'WINTER 2014'
   year: number;
@@ -50,6 +51,10 @@ export function genSeriesId(seasonId: number, rowIndex: number): string {
   return `${seasonId}-${String(rowIndex).padStart(3, '0')}`;
 }
 
+/**
+ * Model of a series combining the voting record from the sheet and metadata
+ * from AniList
+ */
 export interface SeriesModel {
   // Row Index in the voting sheet of this series. Used to uniquely identify the
   // series if a AL Id has not been set
@@ -80,4 +85,21 @@ export interface SeriesVotingRecord {
   weekNum: number;
   votesFor: number;
   votesAgainst: number;
+}
+
+// Top level collection for storing generated ondeck reports
+export const ONDECK_REPORTS_COLLECTION = 'ondeck-reports'
+
+/** Model of a report of a set of episodes to be watched on a particular date */
+export interface OnDeckReport {
+  lastSync: number;           // last time voting sheet was synced
+  created: number;            // date this report was created
+  expectedWatchDate: number;  // expected date these episodes should be watched
+  series: OnDeckReportRow[];
+}
+
+export interface OnDeckReportRow {
+  // TODO: represent title as an Anilist english/native/romaji representation
+  seriesTitle: string;
+  episode: number;
 }


### PR DESCRIPTION
#52 

Added a new storage schema for OnDeckReport, which will be used to power the main page.

This report is generated automatically when syncing from the spreadsheet, and it will include any series which we are currently watching.

Added tests.