### PR TITLE
Updated getOnDeckReport to return latest report if given no arguments

### DIFF
--- a/functions/src/testing/test-data/mockOnDeckReportsData.ts
+++ b/functions/src/testing/test-data/mockOnDeckReportsData.ts
@@ -1,12 +1,36 @@
 import {OnDeckReport} from '../../model/firestore';
 
 export const StandardReport: OnDeckReport = {
+  created: 50,
   lastSync: 50,
   targetWatchDate: 100,
-  created: 50,
   series: [
     {seriesTitle: 'Teekyuu', episode: 3},
     {seriesTitle: 'Aldnoah Zero', episode: 9},
     {seriesTitle: 'Absolute Duo', episode: 10},
   ],
+};
+
+export const TwoHundredReport: OnDeckReport = {
+  ...StandardReport,
+  created: 200,
+  targetWatchDate: 200,
+};
+
+export const RecentReport: OnDeckReport = {
+  ...StandardReport,
+  created: 250,
+  targetWatchDate: 300,
+};
+
+export const OlderReport: OnDeckReport = {
+  ...StandardReport,
+  created: 10,
+  lastSync: 10,
+  targetWatchDate: 20,
+};
+
+export const EmptyReport: OnDeckReport = {
+  ...StandardReport,
+  series: [],
 };


### PR DESCRIPTION
Simple change, always return the latest report if given no arguments. This can be used directly by the frontend.