### PR TITLE
Minor code cleanups

### DIFF
--- a/functions/README.md
+++ b/functions/README.md
@@ -1,0 +1,7 @@
+### Testing
+
+Testing caveat: I am depending on `@google-cloud/firestore` to expose the `Query` class for mocking errors from Firestore.
+
+However, we need to mock the real depdency being used by `firebase-admin`. It is possible for `firebase-admin` to use a different installation from another package during `npm install`. So it may result in errors saying that `@google-cloud/firestore` module doesn't exist.
+
+This can be fixed with a clean npm install some of the time.

--- a/functions/package.json
+++ b/functions/package.json
@@ -32,6 +32,7 @@
   },
   "devDependencies": {
     "@firebase/testing": "^0.16.0",
+    "@google-cloud/firestore": "^3.0.0",
     "@types/jest": "^24.0.23",
     "firebase-functions-test": "^0.1.7",
     "firebase-tools": "^7.8.1",

--- a/functions/package.json
+++ b/functions/package.json
@@ -26,13 +26,11 @@
     "firebase-functions": "^3.3.0",
     "gaxios": "^2.1.0",
     "googleapis": "^45.0.0",
-    "graphql-request": "^1.8.2",
     "node": "^8.13.0",
     "node-fetch": "^2.6.0"
   },
   "devDependencies": {
     "@firebase/testing": "^0.16.0",
-    "@google-cloud/firestore": "^3.0.0",
     "@types/jest": "^24.0.23",
     "firebase-functions-test": "^0.1.7",
     "firebase-tools": "^7.8.1",

--- a/functions/src/getAllSeasons.test.ts
+++ b/functions/src/getAllSeasons.test.ts
@@ -2,6 +2,7 @@
 import 'jest';
 
 import * as firebase from '@firebase/testing';
+// tslint:disable-next-line: no-implicit-dependencies
 import {Query} from '@google-cloud/firestore';
 import admin from 'firebase-admin';
 import * as functions from 'firebase-functions';

--- a/functions/src/getAllSeasons.test.ts
+++ b/functions/src/getAllSeasons.test.ts
@@ -2,6 +2,7 @@
 import 'jest';
 
 import * as firebase from '@firebase/testing';
+import {Query} from '@google-cloud/firestore';
 import admin from 'firebase-admin';
 import * as functions from 'firebase-functions';
 
@@ -56,8 +57,8 @@ describe('getAllSeasons', () => {
   });
 
   test('should return an error if Firebase returns one', async () => {
-    const oldCollection = admin.firestore().collection;
-    admin.firestore().collection = jest.fn(() => {
+    const spy = jest.spyOn(Query.prototype, 'get');
+    spy.mockImplementation(() => {
       throw new FirebaseError(400, 'firebase error');
     });
 
@@ -73,6 +74,6 @@ describe('getAllSeasons', () => {
     expect(res.body).toStrictEqual(
         {err: new FirebaseError(400, 'firebase error')});
 
-    admin.firestore().collection = oldCollection;
+    spy.mockRestore();
   });
 });

--- a/functions/src/getOnDeckReports.test.ts
+++ b/functions/src/getOnDeckReports.test.ts
@@ -2,6 +2,7 @@
 import 'jest';
 
 import * as firebase from '@firebase/testing';
+// tslint:disable-next-line: no-implicit-dependencies
 import {Query} from '@google-cloud/firestore';
 import admin from 'firebase-admin';
 import * as functions from 'firebase-functions';

--- a/functions/src/getSeries.test.ts
+++ b/functions/src/getSeries.test.ts
@@ -2,6 +2,7 @@
 import 'jest';
 
 import * as firebase from '@firebase/testing';
+// tslint:disable-next-line: no-implicit-dependencies
 import {Query} from '@google-cloud/firestore';
 import * as functions from 'firebase-functions';
 import functionsTest from 'firebase-functions-test';

--- a/functions/src/getSeries.test.ts
+++ b/functions/src/getSeries.test.ts
@@ -2,7 +2,7 @@
 import 'jest';
 
 import * as firebase from '@firebase/testing';
-import admin from 'firebase-admin';
+import {Query} from '@google-cloud/firestore';
 import * as functions from 'firebase-functions';
 import functionsTest from 'firebase-functions-test';
 
@@ -66,8 +66,8 @@ describe('getSeries', () => {
   });
 
   test('should return an error if Firebase returns one', async () => {
-    const oldCollectionGroup = admin.firestore().collectionGroup;
-    admin.firestore().collectionGroup = jest.fn(() => {
+    const spy = jest.spyOn(Query.prototype, 'get');
+    spy.mockImplementation(() => {
       throw new FirebaseError(400, 'firebase error');
     });
 
@@ -83,6 +83,6 @@ describe('getSeries', () => {
     expect(res.body).toStrictEqual(
         {err: new FirebaseError(400, 'firebase error')});
 
-    admin.firestore().collectionGroup = oldCollectionGroup;
+    spy.mockRestore();
   });
 });

--- a/functions/src/setSeasonStartDate.test.ts
+++ b/functions/src/setSeasonStartDate.test.ts
@@ -2,6 +2,8 @@
 import 'jest';
 
 import * as firebase from '@firebase/testing';
+// tslint:disable-next-line: no-implicit-dependencies
+import {DocumentReference} from '@google-cloud/firestore';
 import admin from 'firebase-admin';
 import * as functions from 'firebase-functions';
 import functionsTest from 'firebase-functions-test';
@@ -20,7 +22,6 @@ import {setSeasonStartDate} from './setSeasonStartDate.f';
 import {loadTestDataToFirestore} from './testing/loadTestData';
 import {mockSetStartDateMetadataResponse} from './helpers/testing/mockSetStartDateResponse';
 import {START_DATE_METADATA_KEY} from './model/sheets';
-import {Query} from '@google-cloud/firestore';
 
 describe('setSeasonStartDate', () => {
   beforeEach(async () => {
@@ -94,7 +95,7 @@ describe('setSeasonStartDate', () => {
   });
 
   test('should return a 400 and an error if Firebase returns one', async () => {
-    const spy = jest.spyOn(Query.prototype, 'get');
+    const spy = jest.spyOn(DocumentReference.prototype, 'update');
     spy.mockImplementation(() => {
       throw new FirebaseError(400, 'firebase error');
     });

--- a/functions/src/setSeasonStartDate.test.ts
+++ b/functions/src/setSeasonStartDate.test.ts
@@ -20,6 +20,7 @@ import {setSeasonStartDate} from './setSeasonStartDate.f';
 import {loadTestDataToFirestore} from './testing/loadTestData';
 import {mockSetStartDateMetadataResponse} from './helpers/testing/mockSetStartDateResponse';
 import {START_DATE_METADATA_KEY} from './model/sheets';
+import {Query} from '@google-cloud/firestore';
 
 describe('setSeasonStartDate', () => {
   beforeEach(async () => {
@@ -93,8 +94,8 @@ describe('setSeasonStartDate', () => {
   });
 
   test('should return a 400 and an error if Firebase returns one', async () => {
-    const oldCollection = admin.firestore().collection;
-    admin.firestore().collection = jest.fn(() => {
+    const spy = jest.spyOn(Query.prototype, 'get');
+    spy.mockImplementation(() => {
       throw new FirebaseError(400, 'firebase error');
     });
 
@@ -112,6 +113,6 @@ describe('setSeasonStartDate', () => {
     expect(res.body).toStrictEqual(
         {err: new FirebaseError(400, 'firebase error')});
 
-    admin.firestore().collection = oldCollection;
+    spy.mockRestore();
   });
 });


### PR DESCRIPTION
Refactored all other tests using mocks to trigger Firebase Errors to use jest.spyOn.

This resulted in some creative spying, since we need to spy on the class definition of `Query` and friends used by Firebase Admin. However we can't directly depend on `@google-cloud/firebase` as that will cause a duplicate install.

This does pass, but care will need to be taken when installing packages, because only some install orders will work.