### PR TITLE
Given greatly improved user feedback around updating SeriesIds

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1264,6 +1264,14 @@
         "react-transition-group": "^4.3.0"
       }
     },
+    "@material-ui/icons": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-4.5.1.tgz",
+      "integrity": "sha512-YZ/BgJbXX4a0gOuKWb30mBaHaoXRqPanlePam83JQPZ/y4kl+3aW0Wv9tlR70hB5EGAkEJGW5m4ktJwMgxQAeA==",
+      "requires": {
+        "@babel/runtime": "^7.4.4"
+      }
+    },
     "@material-ui/lab": {
       "version": "4.0.0-alpha.36",
       "resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.0.0-alpha.36.tgz",

--- a/app/package.json
+++ b/app/package.json
@@ -7,6 +7,7 @@
     "@date-io/core": "^1.3.13",
     "@date-io/date-fns": "^1.3.13",
     "@material-ui/core": "^4.8.0",
+    "@material-ui/icons": "^4.5.1",
     "@material-ui/lab": "^4.0.0-alpha.36",
     "@material-ui/pickers": "^3.2.8",
     "@types/jest": "^24.0.24",

--- a/app/src/app/App.tsx
+++ b/app/src/app/App.tsx
@@ -92,7 +92,7 @@ const App: React.FC<AppProps> = ({ backendURI }) => {
       if (resp.status === 200) {
         dispatch(AppActions.setSeriesId({
           series: series,
-          seriesId: seriesId,
+          data: resp.data.data,
         }));
         setSuccessMsg(`Updated AniList ID for ${series.titleRaw}`);
         setSuccessOpen(true);

--- a/app/src/app/SeasonDetail.tsx
+++ b/app/src/app/SeasonDetail.tsx
@@ -70,6 +70,12 @@ function SetSeriesIdDialog(props: SetSeriesIdDialog) {
     onClose(value);
   };
 
+  useEffect(() => {
+    if (open) {
+      setValue(series ? series.idAL || 0 : 0);
+    }
+  }, [open, series]);
+
   const valueChanged = (e: ChangeEvent<HTMLInputElement>) => {
     setValue(parseInt(e.target.value));
   }
@@ -151,7 +157,7 @@ const SeasonDetail: React.FC<SeasonDetailProps> = ({ dispatch, backendURI, seaso
 
   const handleSeriesIdDialogConfirm = (seriesId: number) => {
     setDialogOpen(false);
-    if (selectedSeries) {
+    if (selectedSeries && selectedSeries.idAL !== seriesId) {
       onSeriesIdChanged(selectedSeries, season.sheetId, seriesId);
     }
     setSelectedSeries(null);

--- a/app/src/app/Snackbars.tsx
+++ b/app/src/app/Snackbars.tsx
@@ -1,0 +1,125 @@
+import React, { SyntheticEvent } from 'react';
+import clsx from 'clsx';
+import CheckCircleIcon from '@material-ui/icons/CheckCircle';
+import CloseIcon from '@material-ui/icons/Close';
+import { green } from '@material-ui/core/colors';
+import IconButton from '@material-ui/core/IconButton';
+import Snackbar from '@material-ui/core/Snackbar';
+import SnackbarContent from '@material-ui/core/SnackbarContent';
+import ErrorIcon from '@material-ui/icons/Error';
+import { makeStyles, Theme } from '@material-ui/core/styles';
+
+const variantIcon = {
+  success: CheckCircleIcon,
+  error: ErrorIcon,
+};
+
+const useStyles = makeStyles((theme: Theme) => ({
+  success: {
+    backgroundColor: green[600],
+  },
+  error: {
+    backgroundColor: theme.palette.error.dark,
+  },
+  icon: {
+    fontSize: 20,
+  },
+  iconVariant: {
+    opacity: 0.9,
+    marginRight: theme.spacing(1),
+  },
+  message: {
+    display: 'flex',
+    alignItems: 'center',
+  },
+}));
+
+export interface Props {
+  className?: string;
+  message?: string;
+  onClose?: () => void;
+  variant: keyof typeof variantIcon;
+}
+
+function MySnackbarContentWrapper(props: Props) {
+  const classes = useStyles({});
+  const { className, message, onClose, variant, ...other } = props;
+  const Icon = variantIcon[variant];
+
+  return (
+    <SnackbarContent
+      className={clsx(classes[variant], className)}
+      aria-describedby="client-snackbar"
+      message={
+        <span id="client-snackbar" className={classes.message}>
+          <Icon className={clsx(classes.icon, classes.iconVariant)} />
+          {message}
+        </span>
+      }
+      action={[
+        <IconButton key="close" aria-label="close" color="inherit" onClick={onClose}>
+          <CloseIcon className={classes.icon} />
+        </IconButton>,
+      ]}
+      {...other}
+    />
+  );
+}
+
+export function ErrorSnackbar({ open, msg, handleClose }: { open: boolean, msg: string, handleClose: Function }) {
+
+  function onClose(e?: SyntheticEvent, reason?: string) {
+    if (reason === 'clickaway') {
+      return;
+    }
+
+    handleClose(false)
+  }
+
+  return (
+    <Snackbar
+      anchorOrigin={{
+        vertical: 'bottom',
+        horizontal: 'left',
+      }}
+      open={open}
+      autoHideDuration={6000}
+      onClose={onClose}
+    >
+      <MySnackbarContentWrapper
+        onClose={onClose}
+        variant="error"
+        message={msg}
+      />
+    </Snackbar>
+  );
+}
+
+export function SuccessSnackbar({ open, msg, handleClose }: { open: boolean, msg: string, handleClose: Function }) {
+
+  function onClose(e?: SyntheticEvent, reason?: string) {
+    if (reason === 'clickaway') {
+      return;
+    }
+
+    handleClose(false)
+  }
+
+  return (
+    <Snackbar
+      anchorOrigin={{
+        vertical: 'bottom',
+        horizontal: 'left',
+      }}
+      open={open}
+      autoHideDuration={3000}
+      onClose={onClose}
+    >
+      <MySnackbarContentWrapper
+        onClose={onClose}
+        variant="success"
+        message={msg}
+      />
+    </Snackbar>
+  );
+}

--- a/app/src/state/actions.ts
+++ b/app/src/state/actions.ts
@@ -1,4 +1,5 @@
 import {OnDeckReport, SeasonModel, SeriesModel} from '../../../model/firestore';
+import {SetSeriesIdResponse} from '../../../model/service';
 
 import {ActionsUnion, createAction, createActionPayload} from './action_utils';
 
@@ -30,8 +31,8 @@ export const AppActions = {
       typeof SET_SEASON_START_DATE,
       {season: SeasonModel, startDate: Date | null}>(SET_SEASON_START_DATE),
   setSeriesId: createActionPayload<
-      typeof SET_SERIES_ID, {series: SeriesModel, seriesId: number}>(
-      SET_SERIES_ID)
+      typeof SET_SERIES_ID,
+      {series: SeriesModel, data: SetSeriesIdResponse['data']}>(SET_SERIES_ID)
 };
 
 export type AllActions = ActionsUnion<typeof AppActions>;

--- a/app/src/state/reducer.ts
+++ b/app/src/state/reducer.ts
@@ -83,9 +83,8 @@ export function reducer(state: AppState = initialState, action: AllActions) {
           }
 
           // Otherwise, this is the one we want - return an updated value
-          const seriesId = action.payload.seriesId;
           return {
-            ...series, idAL: seriesId || -1,
+            ...series, ...action.payload.data,
           }
         })
       }

--- a/functions/src/setSeriesId.f.ts
+++ b/functions/src/setSeriesId.f.ts
@@ -131,7 +131,13 @@ query ($id: Int) {
     }
 
     const payload: SetSeriesIdResponse = {
-      data: data,
+      data: {
+        titleEn: data.data.Media.title.english,
+        type: data.data.Media.format,
+        idMal: data.data.Media.idMal,
+        idAL: data.data.Media.id,
+        episodes: data.data.Media.episodes,
+      }
     };
     res.status(200).send(payload);
   });

--- a/functions/src/setSeriesId.test.ts
+++ b/functions/src/setSeriesId.test.ts
@@ -92,7 +92,13 @@ describe('setSeriesId', () => {
     await res.sent;
 
     expect(res.statusCode).toEqual(200);
-    expect(res.body!.data).toEqual(mockAnilistQueryMediaResponse);
+    expect(res.body!.data).toEqual({
+      idAL: 15125,
+      idMal: 15125,
+      episodes: 12,
+      titleEn: 'Teekyuu',
+      type: SeriesType.Short,
+    });
   });
 
   test('should store the AniList metadata into Voting Sheet', async () => {

--- a/model/service.ts
+++ b/model/service.ts
@@ -1,4 +1,4 @@
-import {OnDeckReport, SeasonModel, SeriesModel} from './firestore';
+import {OnDeckReport, SeasonModel, SeriesModel, SeriesType} from './firestore';
 
 /**
  * Service messages for Friday Fellows Cloud Functions and client endpoints
@@ -46,7 +46,13 @@ export interface SetSeriesIdRequest {
   seriesId?: number;
 }
 export interface SetSeriesIdResponse {
-  data?: {};  // wip
+  data?: {
+    titleEn: string,
+    idAL: number,
+    idMal: number,
+    episodes: number,
+    type: SeriesType,
+  };
   err?: string;
 }
 


### PR DESCRIPTION
SeriesId Dialog now correctly populates with the ID of the selected series.

Canceling or not editing the SeriesId in the dialog will not trigger a network call.

Successfully updating a SeriesID will update all metadata immediately instead of on refresh.
Successfully updating comes with an success toast.
Errors in updating the SeriesId will popup a Error toast.