### PR TITLE
Adjusted models to account for multiple titles

### DIFF
--- a/app/src/app/App.tsx
+++ b/app/src/app/App.tsx
@@ -94,12 +94,12 @@ const App: React.FC<AppProps> = ({ backendURI }) => {
           series: series,
           data: resp.data.data,
         }));
-        setSuccessMsg(`Updated AniList ID for ${series.titleRaw}`);
+        setSuccessMsg(`Updated AniList ID for ${series.title.raw}`);
         setSuccessOpen(true);
       }
     } catch (e) {
       // console.log(e); // log the error
-      setErrorMsg(`Error when updating AniList ID for ${series.titleRaw}`);
+      setErrorMsg(`Error when updating AniList ID for ${series.title.raw}`);
       setErrorOpen(true);
     }
   }

--- a/app/src/app/OnDeck.tsx
+++ b/app/src/app/OnDeck.tsx
@@ -60,8 +60,8 @@ const OnDeck: React.FC<OnDeckProps> = ({ report, loading = false }) => {
           {!loading && report &&
             <TableBody>
               {report.series.map((series) => (
-                <TableRow key={series.seriesTitle}>
-                  <TableCell component="th" scope="row">{series.seriesTitle}</TableCell>
+                <TableRow key={series.title.raw}>
+                  <TableCell component="th" scope="row">{series.title.raw}</TableCell>
                   <TableCell align="right">{series.episode}</TableCell>
                 </TableRow>
               ))}

--- a/app/src/app/SeasonDetail.tsx
+++ b/app/src/app/SeasonDetail.tsx
@@ -241,7 +241,7 @@ function SeriesVotingGrid({ seriesList }: { seriesList: SeriesModel[] }) {
           {seriesList.map((series) => (
             <TableRow key={series.rowIndex}>
               <TableCell component="th" scope="row">
-                {series.titleRaw}
+                {series.title.raw}
                 {series.idAL !== -1 && <IconButton className={classes.pushLeft} href={`https://anilist.co/anime/${series.idAL}`} target="_blank">
                   <HelpOutlineIcon fontSize="small" />
                 </IconButton>}
@@ -290,9 +290,9 @@ function SeriesDebugGrid({ seriesList, openIDDialog }: { seriesList: SeriesModel
           {seriesList.map((series) => (
             <TableRow key={series.rowIndex}>
               <TableCell component="th" scope="row">
-                {series.titleRaw}
+                {series.title.raw}
               </TableCell>
-              <TableCell>{series.titleEn}</TableCell>
+              <TableCell>{series.title.english}</TableCell>
               <TableCell align="right">{series.idAL}</TableCell>
               <TableCell align="right">{series.idMal}</TableCell>
               <TableCell align="right">{series.type}</TableCell>

--- a/functions/src/config.ts
+++ b/functions/src/config.ts
@@ -30,7 +30,7 @@ export const DEV_SPREADSHEET_ID =
 export const STAGING_SPREADSHEET_ID =
     '11Fo3g9KmR51HxEqDOMzsGZLeq5fU3q6lwxgpl6IH7cE';
 // spreadsheet id config variable actually used by the project
-export const SPREADSHEET_ID = STAGING_SPREADSHEET_ID;
+export const SPREADSHEET_ID = DEV_SPREADSHEET_ID;
 
 /// MAL client configs
 export const MAL_CRED_PATH = 'mal_credentials.json';

--- a/functions/src/getAllSeasons.test.ts
+++ b/functions/src/getAllSeasons.test.ts
@@ -39,7 +39,7 @@ describe('getAllSeasons', () => {
     expect(res.body!.seasons.length).toEqual(2);
     expect(res.body!.seasons[0].startDate!)
         .toBeGreaterThan(res.body!.seasons[1].startDate!);
-    expect(res.body!.lastSyncMs).toEqual(1576882582240);
+    expect(res.body!.lastSyncMs).toEqual(1577325919257);
   });
 
   test('should undefined for last sync if it is missing', async () => {

--- a/functions/src/helpers/aggregateVotingRecordsHelpers.test.ts
+++ b/functions/src/helpers/aggregateVotingRecordsHelpers.test.ts
@@ -21,8 +21,10 @@ const staticSeason: SeasonModel = {
 };
 
 const staticSeries: SeriesModel = {
-  titleEn: 'Teekyuu',
-  titleRaw: 'Teekyuu',
+  title: {
+    raw: 'Teekyuu',
+    english: 'Teekyuu',
+  },
   seasonId: 12345,
   rowIndex: 1,
   type: SeriesType.Short,
@@ -237,7 +239,7 @@ describe('aggregateVotingStatus', () => {
       expect(report!.targetWatchDate).toEqual(mockNow);
       expect(report!.series.length).toEqual(1);
       expect(report!.series).toEqual<OnDeckReportRow[]>([
-        {seriesTitle: staticSeries.titleRaw, episode: 5}
+        {title: {raw: staticSeries.title.raw}, episode: 5}
       ]);
     });
   });

--- a/functions/src/helpers/aggregateVotingRecordsHelpers.ts
+++ b/functions/src/helpers/aggregateVotingRecordsHelpers.ts
@@ -70,7 +70,7 @@ function aggregateCurrentSeason(
 
     if (model.votingStatus === VotingStatus.Watching) {
       report.series.push({
-        seriesTitle: model.titleRaw,
+        title: {raw: model.title.raw},
         episode: calculateNextEpisode(model),
       });
     }

--- a/functions/src/helpers/firestoreDocumentHelpers.test.ts
+++ b/functions/src/helpers/firestoreDocumentHelpers.test.ts
@@ -35,7 +35,7 @@ describe('extractFirestoreDocuments', () => {
 
   test('should build a series model for row model in the sheet', () => {
     const metaPayload: SeriesMetadataPayload = {
-      titleEn: 'Teekyuu English',
+      title: {english: 'Teekyuu English'},
       alId: 12345,
       malId: 54321,
       type: SeriesType.Short,
@@ -63,8 +63,8 @@ describe('extractFirestoreDocuments', () => {
 
     expect(seriesList.length).toEqual(1);
     const series = seriesList[0];
-    expect(series.titleRaw).toEqual('Teekyuu');
-    expect(series.titleEn).toEqual('Teekyuu English');
+    expect(series.title.raw).toEqual('Teekyuu');
+    expect(series.title.english).toEqual('Teekyuu English');
     expect(series.episodes).toEqual(12);
     expect(series.idAL).toEqual(12345);
     expect(series.idMal).toEqual(54321);

--- a/functions/src/helpers/firestoreDocumentHelpers.ts
+++ b/functions/src/helpers/firestoreDocumentHelpers.ts
@@ -1,4 +1,4 @@
-import {Season, SeasonModel, SeriesModel, SeriesType, SeriesVotingRecord, VotingStatus} from '../model/firestore';
+import {Season, SeasonModel, SeriesModel, SeriesTitle, SeriesType, SeriesVotingRecord, VotingStatus} from '../model/firestore';
 import {SERIES_AL_ID_KEY, SeriesMetadataPayload, SpreadsheetModel, START_DATE_METADATA_KEY, WorksheetModel, WorksheetRowModel} from '../model/sheets';
 
 /**
@@ -49,7 +49,24 @@ function extractSeriesDocuments(
   return rows.map((row, index): SeriesModel => {
     const metadataPayload: SeriesMetadataPayload =
         JSON.parse(row.metadata[SERIES_AL_ID_KEY] || '{}');
-    const {alId, malId, episodes, titleEn, type} = metadataPayload;
+    const {alId, malId, episodes, title, type} = metadataPayload;
+    let english, romaji, native = undefined;
+    if (title) {
+      english = title.english;
+      romaji = title.romaji;
+      native = title.native;
+    }
+
+    const seriesTitle: SeriesTitle = {raw: row.cells[0]};
+    if (english) {
+      seriesTitle.english = english;
+    }
+    if (romaji) {
+      seriesTitle.romaji = romaji;
+    }
+    if (native) {
+      seriesTitle.native = native;
+    }
 
     let seriesType = SeriesType.Unknown;
     switch (type) {
@@ -64,8 +81,7 @@ function extractSeriesDocuments(
     const votingRecords = extractSeriesVotingRecord(row.cells.slice(1));
 
     return {
-      titleRaw: row.cells[0] || '',
-      titleEn: titleEn || '',
+      title: seriesTitle,
       rowIndex: index + 1,  // offset for Title row being dropped
       idAL: alId || -1,
       idMal: malId || -1,

--- a/functions/src/setSeriesId.f.ts
+++ b/functions/src/setSeriesId.f.ts
@@ -86,7 +86,11 @@ query ($id: Int) {
       const api = await getSheetsClient(SCOPES);
 
       const metadataPayload: SeriesMetadataPayload = {
-        titleEn: data.data.Media.title.english,
+        title: {
+          english: data.data.Media.title.english,
+          romaji: data.data.Media.title.romaji,
+          native: data.data.Media.title.native,
+        },
         alId: data.data.Media.id,
         malId: data.data.Media.idMal,
         type: data.data.Media.format,
@@ -117,7 +121,11 @@ query ($id: Int) {
           .collection(SERIES_COLLECTION)
           .doc(genSeriesId(seasonId, row))
           .update({
-            titleEn: data.data.Media.title.english,
+            title: {
+              english: data.data.Media.title.english,
+              romaji: data.data.Media.title.romaji,
+              native: data.data.Media.title.native,
+            },
             type: data.data.Media.format,
             idMal: data.data.Media.idMal,
             idAL: data.data.Media.id,
@@ -132,7 +140,11 @@ query ($id: Int) {
 
     const payload: SetSeriesIdResponse = {
       data: {
-        titleEn: data.data.Media.title.english,
+        title: {
+          english: data.data.Media.title.english,
+          romaji: data.data.Media.title.romaji,
+          native: data.data.Media.title.native,
+        },
         type: data.data.Media.format,
         idMal: data.data.Media.idMal,
         idAL: data.data.Media.id,

--- a/functions/src/setSeriesId.test.ts
+++ b/functions/src/setSeriesId.test.ts
@@ -92,11 +92,15 @@ describe('setSeriesId', () => {
     await res.sent;
 
     expect(res.statusCode).toEqual(200);
-    expect(res.body!.data).toEqual({
+    expect(res.body!.data).toEqual<SetSeriesIdResponse['data']>({
       idAL: 15125,
       idMal: 15125,
       episodes: 12,
-      titleEn: 'Teekyuu',
+      title: {
+        english: 'Teekyuu',
+        romaji: 'Teekyuu',
+        native: 'Teekyuu',
+      },
       type: SeriesType.Short,
     });
   });
@@ -116,7 +120,11 @@ describe('setSeriesId', () => {
     await res.sent;
 
     const expectedPayload: SeriesMetadataPayload = {
-      titleEn: 'Teekyuu',
+      title: {
+        english: 'Teekyuu',
+        romaji: 'Teekyuu',
+        native: 'Teekyuu',
+      },
       alId: 15125,
       malId: 15125,
       type: SeriesType.Short,
@@ -170,7 +178,7 @@ describe('setSeriesId', () => {
                            .get();
     const series = seriesSnap.data() as SeriesModel;
 
-    expect(series.titleEn).toBe('Teekyuu');
+    expect(series.title.english).toBe('Teekyuu');
     expect(series.idAL).toBe(15125);
     expect(series.idMal).toBe(15125);
     expect(series.type).toBe('TV_SHORT');

--- a/functions/src/setSeriesId.test.ts
+++ b/functions/src/setSeriesId.test.ts
@@ -99,7 +99,7 @@ describe('setSeriesId', () => {
       title: {
         english: 'Teekyuu',
         romaji: 'Teekyuu',
-        native: 'Teekyuu',
+        native: 'てーきゅう',
       },
       type: SeriesType.Short,
     });
@@ -123,7 +123,7 @@ describe('setSeriesId', () => {
       title: {
         english: 'Teekyuu',
         romaji: 'Teekyuu',
-        native: 'Teekyuu',
+        native: 'てーきゅう',
       },
       alId: 15125,
       malId: 15125,

--- a/functions/src/testing/test-data/firestore.json
+++ b/functions/src/testing/test-data/firestore.json
@@ -2,7 +2,7 @@
   {
     "id": "config/sync-status",
     "data": {
-      "lastSync": 1576882582240
+      "lastSync": 1577325919257
     }
   },
   {
@@ -77,11 +77,12 @@
         }
       ],
       "idMal": 36470,
+      "title": {
+        "raw": "Tada-kun wa Koi wo Shinai"
+      },
       "type": "TV",
-      "titleEn": "Tada Never Falls In Love",
       "seasonId": 1242888778,
       "idAL": 100179,
-      "titleRaw": "Tada-kun wa Koi wo Shinai",
       "rowIndex": 1,
       "episodes": 13
     }
@@ -99,11 +100,12 @@
         }
       ],
       "idMal": 36902,
+      "title": {
+        "raw": "Mahou Shoujo Ore"
+      },
       "type": "TV",
-      "titleEn": "Magical Girl Ore",
       "seasonId": 1242888778,
       "idAL": 100715,
-      "titleRaw": "Mahou Shoujo Ore",
       "rowIndex": 2,
       "episodes": 12
     }
@@ -121,11 +123,12 @@
         }
       ],
       "idMal": 36266,
+      "title": {
+        "raw": "Mahou Shoujo Site"
+      },
       "type": "TV",
-      "titleEn": "MAGICAL GIRL SITE",
       "seasonId": 1242888778,
       "idAL": 100010,
-      "titleRaw": "Mahou Shoujo Site",
       "rowIndex": 3,
       "episodes": 12
     }
@@ -143,11 +146,12 @@
         }
       ],
       "idMal": 35249,
+      "title": {
+        "raw": "Uma Musume: Pretty Derby"
+      },
       "type": "TV",
-      "titleEn": "Umamusume: Pretty Derby",
       "seasonId": 1242888778,
       "idAL": 98514,
-      "titleRaw": "Uma Musume: Pretty Derby",
       "rowIndex": 4,
       "episodes": 13
     }
@@ -201,14 +205,22 @@
           "episodeNum": 6,
           "weekNum": 7,
           "votesFor": 0
+        },
+        {
+          "msg": "PASS",
+          "votesAgainst": 0,
+          "episodeNum": 7,
+          "weekNum": 8,
+          "votesFor": 0
         }
       ],
       "idMal": -1,
+      "title": {
+        "raw": "Megalo Box"
+      },
       "type": "Unknown",
-      "titleEn": "",
       "seasonId": 1242888778,
       "idAL": -1,
-      "titleRaw": "Megalo Box",
       "rowIndex": 5,
       "episodes": -1
     }
@@ -239,11 +251,12 @@
         }
       ],
       "idMal": -1,
+      "title": {
+        "raw": "Ginga Eiyuu Densetsu: Die Neue These - Kaikou"
+      },
       "type": "Unknown",
-      "titleEn": "",
       "seasonId": 1242888778,
       "idAL": -1,
-      "titleRaw": "Ginga Eiyuu Densetsu: Die Neue These - Kaikou",
       "rowIndex": 6,
       "episodes": -1
     }
@@ -300,14 +313,22 @@
           "episodeNum": 6,
           "weekNum": 7,
           "votesFor": 0
+        },
+        {
+          "msg": "PASS",
+          "votesAgainst": 0,
+          "episodeNum": 7,
+          "weekNum": 8,
+          "votesFor": 0
         }
       ],
       "idMal": -1,
+      "title": {
+        "raw": "Gurazeni"
+      },
       "type": "Unknown",
-      "titleEn": "",
       "seasonId": 1242888778,
       "idAL": -1,
-      "titleRaw": "Gurazeni",
       "rowIndex": 7,
       "episodes": -1
     }
@@ -361,14 +382,22 @@
           "episodeNum": 6,
           "weekNum": 7,
           "votesFor": 0
+        },
+        {
+          "msg": "PASS",
+          "votesAgainst": 0,
+          "episodeNum": 7,
+          "weekNum": 8,
+          "votesFor": 0
         }
       ],
       "idMal": -1,
+      "title": {
+        "raw": "Lupin the Third: Part V"
+      },
       "type": "Unknown",
-      "titleEn": "",
       "seasonId": 1242888778,
       "idAL": -1,
-      "titleRaw": "Lupin the Third: Part V",
       "rowIndex": 8,
       "episodes": -1
     }
@@ -398,11 +427,12 @@
         }
       ],
       "idMal": -1,
+      "title": {
+        "raw": "Gegege no Kitaro (2018)"
+      },
       "type": "Unknown",
-      "titleEn": "",
       "seasonId": 1242888778,
       "idAL": -1,
-      "titleRaw": "Gegege no Kitaro (2018)",
       "rowIndex": 9,
       "episodes": -1
     }
@@ -455,14 +485,22 @@
           "episodeNum": 6,
           "weekNum": 7,
           "votesFor": 0
+        },
+        {
+          "msg": "PASS",
+          "votesAgainst": 0,
+          "episodeNum": 7,
+          "weekNum": 8,
+          "votesFor": 0
         }
       ],
       "idMal": 35968,
+      "title": {
+        "raw": "Wotakoi"
+      },
       "type": "TV",
-      "titleEn": "Wotakoi: Love is Hard for Otaku",
       "seasonId": 1242888778,
       "idAL": 99578,
-      "titleRaw": "Wotakoi",
       "rowIndex": 10,
       "episodes": 11
     }
@@ -517,14 +555,22 @@
           "episodeNum": 3,
           "weekNum": 7,
           "votesFor": 0
+        },
+        {
+          "msg": "PASS",
+          "votesAgainst": 0,
+          "episodeNum": 4,
+          "weekNum": 8,
+          "votesFor": 0
         }
       ],
       "idMal": 36397,
+      "title": {
+        "raw": "Shiyan Pin Jiating (Jikken-hin Kazoku)"
+      },
       "type": "TV",
-      "titleEn": "Frankenstein Family",
       "seasonId": 1242888778,
       "idAL": 98477,
-      "titleRaw": "Shiyan Pin Jiating (Jikken-hin Kazoku)",
       "rowIndex": 11,
       "episodes": 12
     }
@@ -554,11 +600,12 @@
         }
       ],
       "idMal": 35756,
+      "title": {
+        "raw": "Comic Girls"
+      },
       "type": "TV",
-      "titleEn": "",
       "seasonId": 1242888778,
       "idAL": 99131,
-      "titleRaw": "Comic Girls",
       "rowIndex": 12,
       "episodes": 12
     }
@@ -611,14 +658,22 @@
           "episodeNum": 44,
           "weekNum": 7,
           "votesFor": 0
+        },
+        {
+          "msg": "PASS",
+          "votesAgainst": 0,
+          "episodeNum": 45,
+          "weekNum": 8,
+          "votesFor": 0
         }
       ],
       "idMal": 36456,
+      "title": {
+        "raw": "Boku no Hero Academia S3"
+      },
       "type": "TV",
-      "titleEn": "My Hero Academia Season 3",
       "seasonId": 1242888778,
       "idAL": 100166,
-      "titleRaw": "Boku no Hero Academia S3",
       "rowIndex": 13,
       "episodes": 25
     }
@@ -671,14 +726,22 @@
           "episodeNum": 6,
           "weekNum": 7,
           "votesFor": 0
+        },
+        {
+          "msg": "PASS",
+          "votesAgainst": 0,
+          "episodeNum": 7,
+          "weekNum": 8,
+          "votesFor": 0
         }
       ],
       "idMal": -1,
+      "title": {
+        "raw": "Golden Kamuy"
+      },
       "type": "Unknown",
-      "titleEn": "",
       "seasonId": 1242888778,
       "idAL": -1,
-      "titleRaw": "Golden Kamuy",
       "rowIndex": 14,
       "episodes": -1
     }
@@ -702,11 +765,12 @@
         }
       ],
       "idMal": -1,
+      "title": {
+        "raw": "Persona 5 the Animation"
+      },
       "type": "Unknown",
-      "titleEn": "",
       "seasonId": 1242888778,
       "idAL": -1,
-      "titleRaw": "Persona 5 the Animation",
       "rowIndex": 15,
       "episodes": -1
     }
@@ -736,11 +800,12 @@
         }
       ],
       "idMal": -1,
+      "title": {
+        "raw": "Piano no Mori"
+      },
       "type": "Unknown",
-      "titleEn": "",
       "seasonId": 1242888778,
       "idAL": -1,
-      "titleRaw": "Piano no Mori",
       "rowIndex": 16,
       "episodes": -1
     }
@@ -764,11 +829,12 @@
         }
       ],
       "idMal": -1,
+      "title": {
+        "raw": "Sword Art Online: Gun Gale Online"
+      },
       "type": "Unknown",
-      "titleEn": "",
       "seasonId": 1242888778,
       "idAL": -1,
-      "titleRaw": "Sword Art Online: Gun Gale Online",
       "rowIndex": 17,
       "episodes": -1
     }
@@ -792,11 +858,12 @@
         }
       ],
       "idMal": -1,
+      "title": {
+        "raw": "Last Period: Owarinaki Rasen no Monogatari"
+      },
       "type": "Unknown",
-      "titleEn": "",
       "seasonId": 1242888778,
       "idAL": -1,
-      "titleRaw": "Last Period: Owarinaki Rasen no Monogatari",
       "rowIndex": 18,
       "episodes": -1
     }
@@ -849,14 +916,22 @@
           "episodeNum": 6,
           "weekNum": 7,
           "votesFor": 0
+        },
+        {
+          "msg": "PASS",
+          "votesAgainst": 0,
+          "episodeNum": 7,
+          "weekNum": 8,
+          "votesFor": 0
         }
       ],
       "idMal": -1,
+      "title": {
+        "raw": "Hinamatsuri"
+      },
       "type": "Unknown",
-      "titleEn": "",
       "seasonId": 1242888778,
       "idAL": -1,
-      "titleRaw": "Hinamatsuri",
       "rowIndex": 19,
       "episodes": -1
     }
@@ -887,11 +962,12 @@
         }
       ],
       "idMal": -1,
+      "title": {
+        "raw": "Mitsuboshi Colors"
+      },
       "type": "Unknown",
-      "titleEn": "",
       "seasonId": 281991772,
       "idAL": -1,
-      "titleRaw": "Mitsuboshi Colors",
       "rowIndex": 1,
       "episodes": -1
     }
@@ -909,11 +985,12 @@
         }
       ],
       "idMal": -1,
+      "title": {
+        "raw": "Karakai Jouzu no Takagi-san"
+      },
       "type": "Unknown",
-      "titleEn": "",
       "seasonId": 281991772,
       "idAL": -1,
-      "titleRaw": "Karakai Jouzu no Takagi-san",
       "rowIndex": 2,
       "episodes": -1
     }
@@ -931,11 +1008,12 @@
         }
       ],
       "idMal": -1,
+      "title": {
+        "raw": "Hakata Tonkotsu Ramens"
+      },
       "type": "Unknown",
-      "titleEn": "",
       "seasonId": 281991772,
       "idAL": -1,
-      "titleRaw": "Hakata Tonkotsu Ramens",
       "rowIndex": 3,
       "episodes": -1
     }
@@ -975,14 +1053,22 @@
           "episodeNum": 4,
           "weekNum": 5,
           "votesFor": 4
+        },
+        {
+          "msg": "PASS",
+          "votesAgainst": 0,
+          "episodeNum": 5,
+          "weekNum": 6,
+          "votesFor": 0
         }
       ],
       "idMal": -1,
+      "title": {
+        "raw": "Koi wa Ameagari no You ni"
+      },
       "type": "Unknown",
-      "titleEn": "",
       "seasonId": 281991772,
       "idAL": -1,
-      "titleRaw": "Koi wa Ameagari no You ni",
       "rowIndex": 4,
       "episodes": -1
     }
@@ -1013,11 +1099,12 @@
         }
       ],
       "idMal": -1,
+      "title": {
+        "raw": "Ryuuou no Oshigoto"
+      },
       "type": "Unknown",
-      "titleEn": "",
       "seasonId": 281991772,
       "idAL": -1,
-      "titleRaw": "Ryuuou no Oshigoto",
       "rowIndex": 5,
       "episodes": -1
     }
@@ -1035,11 +1122,12 @@
         }
       ],
       "idMal": -1,
+      "title": {
+        "raw": "Gakuen Babysitters"
+      },
       "type": "Unknown",
-      "titleEn": "",
       "seasonId": 281991772,
       "idAL": -1,
-      "titleRaw": "Gakuen Babysitters",
       "rowIndex": 6,
       "episodes": -1
     }
@@ -1079,14 +1167,22 @@
           "episodeNum": 4,
           "weekNum": 5,
           "votesFor": 4
+        },
+        {
+          "msg": "PASS",
+          "votesAgainst": 0,
+          "episodeNum": 5,
+          "weekNum": 6,
+          "votesFor": 0
         }
       ],
       "idMal": -1,
+      "title": {
+        "raw": "Sora yori mo Tooi Basho"
+      },
       "type": "Unknown",
-      "titleEn": "",
       "seasonId": 281991772,
       "idAL": -1,
-      "titleRaw": "Sora yori mo Tooi Basho",
       "rowIndex": 7,
       "episodes": -1
     }
@@ -1126,14 +1222,22 @@
           "episodeNum": 4,
           "weekNum": 5,
           "votesFor": 4
+        },
+        {
+          "msg": "PASS",
+          "votesAgainst": 0,
+          "episodeNum": 5,
+          "weekNum": 6,
+          "votesFor": 0
         }
       ],
       "idMal": -1,
+      "title": {
+        "raw": "Violet Evergarden"
+      },
       "type": "Unknown",
-      "titleEn": "",
       "seasonId": 281991772,
       "idAL": -1,
-      "titleRaw": "Violet Evergarden",
       "rowIndex": 8,
       "episodes": -1
     }
@@ -1151,11 +1255,12 @@
         }
       ],
       "idMal": -1,
+      "title": {
+        "raw": "Märchen Mädchen"
+      },
       "type": "Unknown",
-      "titleEn": "",
       "seasonId": 281991772,
       "idAL": -1,
-      "titleRaw": "Märchen Mädchen",
       "rowIndex": 9,
       "episodes": -1
     }
@@ -1195,14 +1300,22 @@
           "episodeNum": 4,
           "weekNum": 5,
           "votesFor": 4
+        },
+        {
+          "msg": "PASS",
+          "votesAgainst": 0,
+          "episodeNum": 5,
+          "weekNum": 6,
+          "votesFor": 0
         }
       ],
       "idMal": -1,
+      "title": {
+        "raw": "Devilman Crybaby"
+      },
       "type": "Unknown",
-      "titleEn": "",
       "seasonId": 281991772,
       "idAL": -1,
-      "titleRaw": "Devilman Crybaby",
       "rowIndex": 10,
       "episodes": -1
     }
@@ -1233,11 +1346,12 @@
         }
       ],
       "idMal": -1,
+      "title": {
+        "raw": "Beatless"
+      },
       "type": "Unknown",
-      "titleEn": "",
       "seasonId": 281991772,
       "idAL": -1,
-      "titleRaw": "Beatless",
       "rowIndex": 11,
       "episodes": -1
     }
@@ -1267,11 +1381,12 @@
         }
       ],
       "idMal": -1,
+      "title": {
+        "raw": "Darling in the Franxx"
+      },
       "type": "Unknown",
-      "titleEn": "",
       "seasonId": 281991772,
       "idAL": -1,
-      "titleRaw": "Darling in the Franxx",
       "rowIndex": 12,
       "episodes": -1
     }
@@ -1301,11 +1416,12 @@
         }
       ],
       "idMal": -1,
+      "title": {
+        "raw": "Hakumei to Mikochi"
+      },
       "type": "Unknown",
-      "titleEn": "",
       "seasonId": 281991772,
       "idAL": -1,
-      "titleRaw": "Hakumei to Mikochi",
       "rowIndex": 13,
       "episodes": -1
     }
@@ -1329,11 +1445,12 @@
         }
       ],
       "idMal": -1,
+      "title": {
+        "raw": "Toji no Miko"
+      },
       "type": "Unknown",
-      "titleEn": "",
       "seasonId": 281991772,
       "idAL": -1,
-      "titleRaw": "Toji no Miko",
       "rowIndex": 14,
       "episodes": -1
     }
@@ -1372,14 +1489,22 @@
           "episodeNum": 4,
           "weekNum": 5,
           "votesFor": 5
+        },
+        {
+          "msg": "PASS",
+          "votesAgainst": 0,
+          "episodeNum": 5,
+          "weekNum": 6,
+          "votesFor": 0
         }
       ],
       "idMal": -1,
+      "title": {
+        "raw": "Pop Team Epic"
+      },
       "type": "Unknown",
-      "titleEn": "",
       "seasonId": 281991772,
       "idAL": -1,
-      "titleRaw": "Pop Team Epic",
       "rowIndex": 15,
       "episodes": -1
     }
@@ -1403,11 +1528,12 @@
         }
       ],
       "idMal": -1,
+      "title": {
+        "raw": "Citrus"
+      },
       "type": "Unknown",
-      "titleEn": "",
       "seasonId": 281991772,
       "idAL": -1,
-      "titleRaw": "Citrus",
       "rowIndex": 16,
       "episodes": -1
     }
@@ -1437,11 +1563,12 @@
         }
       ],
       "idMal": -1,
+      "title": {
+        "raw": "Death March kara Hajimaru Isekai Kyousoukyoku"
+      },
       "type": "Unknown",
-      "titleEn": "",
       "seasonId": 281991772,
       "idAL": -1,
-      "titleRaw": "Death March kara Hajimaru Isekai Kyousoukyoku",
       "rowIndex": 17,
       "episodes": -1
     }
@@ -1465,11 +1592,12 @@
         }
       ],
       "idMal": -1,
+      "title": {
+        "raw": "Dame x Prince Anime Caravan"
+      },
       "type": "Unknown",
-      "titleEn": "",
       "seasonId": 281991772,
       "idAL": -1,
-      "titleRaw": "Dame x Prince Anime Caravan",
       "rowIndex": 18,
       "episodes": -1
     }
@@ -1511,11 +1639,12 @@
         }
       ],
       "idMal": -1,
+      "title": {
+        "raw": "Ito Junji: Collection"
+      },
       "type": "Unknown",
-      "titleEn": "",
       "seasonId": 281991772,
       "idAL": -1,
-      "titleRaw": "Ito Junji: Collection",
       "rowIndex": 19,
       "episodes": -1
     }
@@ -1539,11 +1668,12 @@
         }
       ],
       "idMal": -1,
+      "title": {
+        "raw": "Sanrio Danshi"
+      },
       "type": "Unknown",
-      "titleEn": "",
       "seasonId": 281991772,
       "idAL": -1,
-      "titleRaw": "Sanrio Danshi",
       "rowIndex": 20,
       "episodes": -1
     }
@@ -1582,14 +1712,22 @@
           "episodeNum": 4,
           "weekNum": 5,
           "votesFor": 3
+        },
+        {
+          "msg": "PASS",
+          "votesAgainst": 0,
+          "episodeNum": 5,
+          "weekNum": 6,
+          "votesFor": 0
         }
       ],
       "idMal": -1,
+      "title": {
+        "raw": "Yurucamp"
+      },
       "type": "Unknown",
-      "titleEn": "",
       "seasonId": 281991772,
       "idAL": -1,
-      "titleRaw": "Yurucamp",
       "rowIndex": 21,
       "episodes": -1
     }
@@ -1619,53 +1757,70 @@
         }
       ],
       "idMal": -1,
+      "title": {
+        "raw": "Mahoutsukai no Yome"
+      },
       "type": "Unknown",
-      "titleEn": "",
       "seasonId": 281991772,
       "idAL": -1,
-      "titleRaw": "Mahoutsukai no Yome",
       "rowIndex": 22,
       "episodes": -1
     }
   },
   {
-    "id": "ondeck-reports/dj7iTSo1255KcvybgNpy",
+    "id": "ondeck-reports/zbOblqrYg0oHdrkQTaw9",
     "data": {
-      "created": 1576882582238,
-      "lastSync": 1576882582240,
-      "targetWatchDate": 1576882582238,
+      "created": 1577325919255,
+      "lastSync": 1577325919257,
+      "targetWatchDate": 1577325919255,
       "series": [
         {
-          "episode": 7,
-          "seriesTitle": "Megalo Box"
+          "episode": 8,
+          "title": {
+            "raw": "Megalo Box"
+          }
         },
         {
-          "episode": 7,
-          "seriesTitle": "Gurazeni"
+          "episode": 8,
+          "title": {
+            "raw": "Gurazeni"
+          }
         },
         {
-          "episode": 7,
-          "seriesTitle": "Lupin the Third: Part V"
+          "episode": 8,
+          "title": {
+            "raw": "Lupin the Third: Part V"
+          }
         },
         {
-          "episode": 7,
-          "seriesTitle": "Wotakoi"
+          "episode": 8,
+          "title": {
+            "raw": "Wotakoi"
+          }
         },
         {
-          "episode": 4,
-          "seriesTitle": "Shiyan Pin Jiating (Jikken-hin Kazoku)"
+          "episode": 5,
+          "title": {
+            "raw": "Shiyan Pin Jiating (Jikken-hin Kazoku)"
+          }
         },
         {
-          "episode": 45,
-          "seriesTitle": "Boku no Hero Academia S3"
+          "episode": 46,
+          "title": {
+            "raw": "Boku no Hero Academia S3"
+          }
         },
         {
-          "episode": 7,
-          "seriesTitle": "Golden Kamuy"
+          "episode": 8,
+          "title": {
+            "raw": "Golden Kamuy"
+          }
         },
         {
-          "episode": 7,
-          "seriesTitle": "Hinamatsuri"
+          "episode": 8,
+          "title": {
+            "raw": "Hinamatsuri"
+          }
         }
       ]
     }

--- a/functions/src/testing/test-data/mockOnDeckReportsData.ts
+++ b/functions/src/testing/test-data/mockOnDeckReportsData.ts
@@ -5,9 +5,9 @@ export const StandardReport: OnDeckReport = {
   lastSync: 50,
   targetWatchDate: 100,
   series: [
-    {seriesTitle: 'Teekyuu', episode: 3},
-    {seriesTitle: 'Aldnoah Zero', episode: 9},
-    {seriesTitle: 'Absolute Duo', episode: 10},
+    {title: {raw: 'Teekyuu'}, episode: 3},
+    {title: {raw: 'Aldnoah Zero'}, episode: 9},
+    {title: {raw: 'Absolute Duo'}, episode: 10},
   ],
 };
 

--- a/model/firestore.ts
+++ b/model/firestore.ts
@@ -51,6 +51,13 @@ export function genSeriesId(seasonId: number, rowIndex: number): string {
   return `${seasonId}-${String(rowIndex).padStart(3, '0')}`;
 }
 
+export interface SeriesTitle {
+  raw?: string;  // from spreadsheet
+  english?: string;
+  romaji?: string;
+  native?: string;
+}
+
 /**
  * Model of a series combining the voting record from the sheet and metadata
  * from AniList
@@ -59,8 +66,7 @@ export interface SeriesModel {
   // Row Index in the voting sheet of this series. Used to uniquely identify the
   // series if a AL Id has not been set
   rowIndex: number;
-  titleRaw: string;  // Raw title from Voting Sheet
-  titleEn: string;   // English title from AniList
+  title: SeriesTitle;
   type: SeriesType;
   idMal?: number;
   idAL?: number;
@@ -99,7 +105,6 @@ export interface OnDeckReport {
 }
 
 export interface OnDeckReportRow {
-  // TODO: represent title as an Anilist english/native/romaji representation
-  seriesTitle: string;
+  title: SeriesTitle;
   episode: number;
 }

--- a/model/service.ts
+++ b/model/service.ts
@@ -1,4 +1,4 @@
-import {OnDeckReport, SeasonModel, SeriesModel, SeriesType} from './firestore';
+import {OnDeckReport, SeasonModel, SeriesModel, SeriesTitle, SeriesType} from './firestore';
 
 /**
  * Service messages for Friday Fellows Cloud Functions and client endpoints
@@ -47,7 +47,7 @@ export interface SetSeriesIdRequest {
 }
 export interface SetSeriesIdResponse {
   data?: {
-    titleEn: string,
+    title: SeriesTitle,
     idAL: number,
     idMal: number,
     episodes: number,

--- a/model/sheets.ts
+++ b/model/sheets.ts
@@ -1,3 +1,5 @@
+import {SeriesTitle} from './firestore';
+
 /**
  * Set of type interfaces for storing and interacting with spreadsheets data.
  */
@@ -32,7 +34,7 @@ export interface SeriesMetadataPayload {
   malId: number;
   type: string;
   episodes: number;
-  titleEn: string;
+  title: SeriesTitle;
 }
 
 /**


### PR DESCRIPTION
Now saves Raw, English, Romaji, Native titles into the metadata when pulled from AniList. Currently always displays the english or raw as  before. Can be easily improved to show a user preferred title scheme. 

Old stored metadata will work, but won't display any titles. I need to recycle all known metadata to store the updated titles in the correct locations.