### PR TITLE
Displaying Real dates, season names, weeks on OnDeck Reports

### DIFF
--- a/app/src/app/OnDeck.tsx
+++ b/app/src/app/OnDeck.tsx
@@ -42,12 +42,24 @@ interface OnDeckProps {
 const OnDeck: React.FC<OnDeckProps> = ({ report, loading = false }) => {
   const classes = useStyles();
 
+  function formatTargetDate(targetDate: number | undefined) {
+    if (!targetDate) {
+      return 'Unknown';
+    }
+
+    return new Intl.DateTimeFormat('en-US', {
+      year: 'numeric',
+      month: 'numeric',
+      day: '2-digit'
+    }).format(new Date(targetDate));
+  }
+
   return (
     <div>
       <Paper className={classes.header}>
-        <span className={classes.headerSegment}>Fall 2019</span>
-        <span className={classes.headerSegment}>Week 10</span>
-        <span className={classes.headerSegment}>Next Session: 11/22/2019</span>
+        <span className={classes.headerSegment}>{report?.seasonName}</span>
+        <span className={classes.headerSegment}>Week {report?.week}</span>
+        <span className={classes.headerSegment}>Next Session: {formatTargetDate(report?.targetWatchDate)}</span>
       </Paper>
       <Paper className={classes.paperBody}>
         <Table className={classes.table} aria-label="simple table">

--- a/functions/src/helpers/aggregateVotingRecordsHelpers.test.ts
+++ b/functions/src/helpers/aggregateVotingRecordsHelpers.test.ts
@@ -229,14 +229,16 @@ describe('aggregateVotingStatus', () => {
           episodeNum: 4,
         }]
       };
+      const expectedTargetDate = new Date(currentSeason.startDate);
+      expectedTargetDate.setDate(expectedTargetDate.getDate() + 4 * 7);
+      const expectedTargetTime = expectedTargetDate.getTime();
 
       const report = aggregateVotingStatus(currentSeason, [watchingSeries]);
 
       expect(report).toBeTruthy();
       expect(report!.lastSync).toEqual(-1);
       expect(report!.created).toEqual(mockNow);
-      // TODO: calculate next friday
-      expect(report!.targetWatchDate).toEqual(mockNow);
+      expect(report!.targetWatchDate).toEqual(expectedTargetTime);
       expect(report!.series.length).toEqual(1);
       expect(report!.series).toEqual<OnDeckReportRow[]>([
         {title: {raw: staticSeries.title.raw}, episode: 5}

--- a/functions/src/helpers/aggregateVotingRecordsHelpers.ts
+++ b/functions/src/helpers/aggregateVotingRecordsHelpers.ts
@@ -58,10 +58,15 @@ function calculateOlderVotingStatus(series: SeriesModel): VotingStatus {
  */
 function aggregateCurrentSeason(
     season: SeasonModel, series: SeriesModel[], weekNum: number): OnDeckReport {
+  const targetDate = new Date(season.startDate!);
+  targetDate.setDate(targetDate.getDate() + weekNum * 7);
+
   const report: OnDeckReport = {
     lastSync: -1,
     created: Date.now(),
-    targetWatchDate: Date.now(),  // TODO: Calculate the next Friday
+    targetWatchDate: targetDate.getTime(),
+    seasonName: season.formattedName,
+    week: weekNum + 1,
     series: [],
   };
   series.forEach((model: SeriesModel) => {

--- a/functions/src/testing/test-data/mockOnDeckReportsData.ts
+++ b/functions/src/testing/test-data/mockOnDeckReportsData.ts
@@ -4,6 +4,8 @@ export const StandardReport: OnDeckReport = {
   created: 50,
   lastSync: 50,
   targetWatchDate: 100,
+  seasonName: 'FALL 2019',
+  week: 3,
   series: [
     {title: {raw: 'Teekyuu'}, episode: 3},
     {title: {raw: 'Aldnoah Zero'}, episode: 9},

--- a/model/firestore.ts
+++ b/model/firestore.ts
@@ -100,6 +100,8 @@ export const ONDECK_REPORTS_COLLECTION = 'ondeck-reports';
 export interface OnDeckReport {
   lastSync: number;         // last time voting sheet was synced
   created: number;          // date this report was created
+  seasonName: string;       // e.g. FALL 2019
+  week: number              // week number through the season
   targetWatchDate: number;  // expected date these episodes should be watched
   series: OnDeckReportRow[];
 }


### PR DESCRIPTION
Tracks and stores timing information for OnDeckReports. WebUI will display the appropriate information.

#65 